### PR TITLE
fixed formatting of docstrings for Sphinx

### DIFF
--- a/idmtools_platform_local/idmtools_platform_local/client/simulations_client.py
+++ b/idmtools_platform_local/idmtools_platform_local/client/simulations_client.py
@@ -59,6 +59,7 @@ class SimulationsClient(BaseClient):
     def cancel(cls, id: str) -> Dict[str, Any]:
         """
         Marks a simulation to be canceled. Canceled jobs are only truly canceled when the queue message is processed
+        
         Args:
             id (st):
 

--- a/idmtools_platform_local/idmtools_platform_local/infrastructure/service_manager.py
+++ b/idmtools_platform_local/idmtools_platform_local/infrastructure/service_manager.py
@@ -72,7 +72,8 @@ class DockerServiceManager:
     def cleanup(self, delete_data: bool = False, tear_down_brokers: bool = False) -> NoReturn:
         """
         Stops the containers and removes the network. Optionally the postgres data container can be deleted as well
-            as closing any active Redis connections
+        as closing any active Redis connections
+        
         Args:
             delete_data: Delete postgres data
             tear_down_brokers: True to close redis brokers, false otherwise
@@ -158,7 +159,8 @@ class DockerServiceManager:
                               sleep_after: Union[int, float] = 0.5) -> bool:
         """
         Polls list of port attributes(eg postgres_port, redis_port and checks if they are currently open. We use this
-            to verify postgres/redis are ready for our workers
+        to verify postgres/redis are ready for our workers
+        
         Args:
             ports: List of port attributes
             wait_between_tries: Time between port checks

--- a/idmtools_platform_local/idmtools_platform_local/platform_operations/experiment_operations.py
+++ b/idmtools_platform_local/idmtools_platform_local/platform_operations/experiment_operations.py
@@ -27,6 +27,7 @@ class LocalPlatformExperimentOperations(IPlatformExperimentOperations):
     def get(self, experiment_id: UUID, **kwargs) -> ExperimentDict:
         """
         Get the experiment object by id
+
         Args:
             experiment_id: Id
             **kwargs:
@@ -102,6 +103,7 @@ class LocalPlatformExperimentOperations(IPlatformExperimentOperations):
     def get_parent(self, experiment: Any, **kwargs) -> None:
         """
         Experiment on local platform have no parents so return None
+
         Args:
             experiment:
             **kwargs:
@@ -114,6 +116,7 @@ class LocalPlatformExperimentOperations(IPlatformExperimentOperations):
     def run_item(self, experiment: IExperiment):
         """
         Run the experiment
+
         Args:
             experiment: experiment to run
 
@@ -135,7 +138,8 @@ class LocalPlatformExperimentOperations(IPlatformExperimentOperations):
     def send_assets(self, experiment: IExperiment):
         """
 
-         Sends assets for specified experiment
+        Sends assets for specified experiment
+        
         Args:
             experiment: Experiment to send assets for
 
@@ -209,6 +213,7 @@ class LocalPlatformExperimentOperations(IPlatformExperimentOperations):
     def _launch_item_in_browser(self, item):
         """
         Launch experiment data page in a web browser
+        
         Args:
             item:
 


### PR DESCRIPTION
Fixed docstring formatting for a few of the local platform modules to build in Sphinx. There is another PR in the docs repo to add API docs for the COMPS and local platforms. Note that I had to remove some of the local/infrastructure/internals modules from the docs because I was getting errors about missing a pika package and something regarding Docker. Let me know if it's necessary to get them all documented and I can try to troubleshoot those errors more. 