### PR TITLE
Adding id property to all IItem types (Fix #619)

### DIFF
--- a/idmtools_core/idmtools/core/interfaces/iitem.py
+++ b/idmtools_core/idmtools/core/interfaces/iitem.py
@@ -18,6 +18,10 @@ class IItem:
         self._uid = uid
 
     @property
+    def id(self):
+        return str(self.uid)
+
+    @property
     def metadata(self):
         attrs = set(vars(self).keys())
         obj_dict = {k: getattr(self, k) for k in attrs.intersection(self.metadata_fields)}


### PR DESCRIPTION
This change makes it so that all simulation, experiment, suite objects (anything derived from IItem) have a .id property that simply converts .uid to a string.

There is no setter for id, so the current route of setting only uid means that uid/id are always in sync with each other.