### PR TITLE
Adding way to exclude simulations in analysis (Fix #614)

### DIFF
--- a/idmtools_platform_comps/requirements.txt
+++ b/idmtools_platform_comps/requirements.txt
@@ -1,5 +1,5 @@
 backoff~=1.8.1
 humanfriendly~=4.18
 idmtools~=0.3.0
-pyCOMPS~=2.3.5
+pyCOMPS~=2.3.6
 tqdm~=4.39


### PR DESCRIPTION
I manually tested these changes by trying to exclude the following from an experiment with four simulations:

No simulations (four analyzed)
two simulations in the analyzed experiment (two analyzed)
one simulation in the experiment and one mis-entered simulation (three analyzed)
I also verified that passing in str and UUID sim ids were equivalent.