### PR TITLE
Fix a bug in RequirementToAssetCellection Utility (#791)

### DIFF
--- a/idmtools_platform_comps/idmtools_platform_comps/utils/python_requirements_ac/create_asset_collection.py
+++ b/idmtools_platform_comps/idmtools_platform_comps/utils/python_requirements_ac/create_asset_collection.py
@@ -10,7 +10,7 @@ AC_FILE = 'ac_info.txt'
 LIBRARY_ROOT_PREFIX = 'L'
 
 
-def build_asset_file_list_new(comps_sim, prefix=LIBRARY_ROOT_PREFIX):
+def build_asset_file_list(comps_sim, prefix=LIBRARY_ROOT_PREFIX):
     """
     Utility function to build all library files
     Args:


### PR DESCRIPTION
This PR aims to fix the following bug:

#791: Missing asset file with RequirementsToAssetCollection