### PR TITLE
Merge back to dev - fix for dataclasses in python3.6

### DIFF
--- a/idmtools_core/setup.py
+++ b/idmtools_core/setup.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """The setup script for the idmtools_core platform, the core tools for modeling and analysis."""
+import sys
+
 from setuptools import setup, find_packages
 
 with open('README.md') as readme_file:
@@ -36,6 +38,9 @@ authors = [
     ("Jen Schripsema", "jschripsema@idmod.org")
 ]
 
+# check for python 3.6
+if sys.version_info[1] == 6:
+    requirements.append('dataclasses')
 
 setup(
     author=[author[0] for author in authors],


### PR DESCRIPTION
Fix #802 missing dataclasses for python 3.6 for idmtools-core pakcage
Tested new ssmt image build with python 3.6 in idmtvapp17 docker server with this fix.