### PR TITLE
Add back previous delete test packages, need them to run tests after …

### DIFF
--- a/idmtools_core/setup.py
+++ b/idmtools_core/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt') as requirements_file:
     requirements = requirements_file.read().split("\n")
 
 build_requirements = ['flake8', 'coverage', 'py-make', 'bump2version', 'twine']
-test_requirements = ['pytest', 'pytest-runner', 'xmlrunner', 'pytest-xdist',
+test_requirements = ['pytest~=5.4.1', 'pytest-runner~=5.2', 'xmlrunner~=1.7.7', 'pytest-xdist',
                      'pytest-timeout', 'pytest-cache'] + build_requirements
 
 extras = {

--- a/idmtools_test/requirements.txt
+++ b/idmtools_test/requirements.txt
@@ -1,4 +1,11 @@
 idmtools~=1.0.1
-pytest
-pytest-runner
-xmlrunner
+pytest~=5.4.1
+pytest-runner~=5.2
+xmlrunner~=1.7.7
+sqlalchemy~=1.3.5
+psycopg2-binary~=2.8.4
+flask~=1.1
+Flask-AutoIndex~=0.6.6
+flask_restful~=0.3.7
+Flask-SQLAlchemy~=2.4.0
+matplotlib~=3.2.1


### PR DESCRIPTION
This should not affect any idmtools packages. just add ability to run tests to validate artifactory package installation. since we do not install all test extra package with pip install idmtools[full] --url ...
