### PR TITLE
#768 updated breadcrumb trail to point to idmod.org/documentation

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -8,7 +8,7 @@
 
 <div aria-label="breadcrumbs navigation" role="navigation">
     <ul class="wy-breadcrumbs">
-        <li><a href="../index.html">IDM docs</a> &raquo;</li>
+        <li><a href="https://idmod.org/documentation">IDM docs</a> &raquo;</li>
         <li><a href="{{ pathto(master_doc) }}">IDM-Tools</a> &raquo;</li>
         {% for doc in parents %}
         <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>


### PR DESCRIPTION
The breadcrumb trail that points back to all IDM software documentation is no longer relative (../index.html) and now points to https://idmod.org/documentation. Unfortunately, this means if you are viewing "WIP" versions of IDM-Tools you won't be able to see the WIP doc landing page, but is the best solution until we move everything to Read the Docs. 