### PR TITLE
Changed name from IDM-Tools to idmtools in docs and code comments

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -9,7 +9,7 @@
 <div aria-label="breadcrumbs navigation" role="navigation">
     <ul class="wy-breadcrumbs">
         <li><a href="https://idmod.org/documentation">IDM docs</a> &raquo;</li>
-        <li><a href="{{ pathto(master_doc) }}">IDM-Tools</a> &raquo;</li>
+        <li><a href="{{ pathto(master_doc) }}">idmtools</a> &raquo;</li>
         {% for doc in parents %}
         <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
         {% endfor %}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,6 +1,6 @@
 {% extends '!footer.html' %}
 {% block extrafooter %}
-<p>IDM-Tools is licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode">Creative Commons
+<p>idmtools is licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode">Creative Commons
     Attribution-Noncommercial-ShareAlike 4.0 License</a>.</p>
 <p>Send documentation feedback to <a href="mailto:feedback@idmod.org" target="_top">feedback@idmod.org</a>. If you have
     questions, email <a href="mailto:support@idmod.org" target="_top">support@idmod.org</a>.</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'IDM-Tools'
+project = u'idmtools'
 copyright = u'2020, Intellectual Ventures Management, LLC (IVM). All rights reserved'
 author = u'Institute for Disease Modeling'
 
@@ -296,7 +296,7 @@ html_use_opensearch = 'www.idmod.org/docs/'
 # html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'IDM-Tools'
+htmlhelp_basename = 'idmtools'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -322,7 +322,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'idm-tools-docs.tex', u'IDM-Tools',
+    (master_doc, 'idmtools-docs.tex', u'idmtools',
      u'Institute for Disease Modeling', 'manual'),
 ]
 
@@ -364,7 +364,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'idm-tools-docs', u'IDM-Tools',
+    (master_doc, 'idmtools-docs', u'idmtools',
      [author], 1)
 ]
 
@@ -378,8 +378,8 @@ man_show_urls = True
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'idm-tools-docs', u'IDM-Tools',
-     author, 'Institute for Disease Modeling', 'How to use IDM-Tools for disease simulations.',
+    (master_doc, 'idmtools-docs', u'idmtools',
+     author, 'Institute for Disease Modeling', 'How to use idmtools for disease simulations.',
      'Miscellaneous'),
 ]
 

--- a/docs/diagrams/analyzers-convert.puml
+++ b/docs/diagrams/analyzers-convert.puml
@@ -14,7 +14,7 @@ class BaseAnalyzer {
 }
 
 note top of IAnalyzer
-IDM-Tools
+idmtools
 end note
 
 class IAnalyzer {

--- a/docs/overview.rst_for_later
+++ b/docs/overview.rst_for_later
@@ -2,7 +2,7 @@
 Overview
 ========
 
-What is IDM-tools
+What is idmtools
 What does it do
 Features
 ETC

--- a/docs/variables.txt
+++ b/docs/variables.txt
@@ -19,7 +19,7 @@
 .. |EMOD_l| replace:: Epidemiological MODeling software (EMOD)
 .. |EMOD_s| replace:: EMOD
 .. |IT_l| replace:: IDM Modeling Tools
-.. |IT_s| replace:: IDM-Tools
+.. |IT_s| replace:: idmtools
 .. |Python_IT| replace:: Python 3.6 or 3.7 64-bit
 .. |SSMT_l| replace:: Server-Side Modeling Tools (SSMT)
 .. |SSMT_s| replace:: SSMT

--- a/examples/idmtools.ini
+++ b/examples/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/examples/load_lib/idmtools.ini
+++ b/examples/load_lib/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/examples/ssmt/generic_ssmt/files/idmtools.ini
+++ b/examples/ssmt/generic_ssmt/files/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/examples/ssmt/idmtools.ini
+++ b/examples/ssmt/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/examples/ssmt/more_mutiple_analyzers/idmtools.ini
+++ b/examples/ssmt/more_mutiple_analyzers/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/examples/ssmt/simple_analysis/idmtools.ini
+++ b/examples/ssmt/simple_analysis/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools.ini
+++ b/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_core/idmtools/config/idm_config_parser.py
+++ b/idmtools_core/idmtools/config/idm_config_parser.py
@@ -122,7 +122,7 @@ class IdmConfigParser:
         Returns:
             None
         """
-        # init logging here as this is our most likely entry-point into an idm-tools "application"
+        # init logging here as this is our most likely entry-point into an idmtools "application"
         from idmtools.core.logging import setup_logging, VERBOSE
 
         ini_file = cls._find_config(dir_path, file_name)

--- a/idmtools_core/idmtools/entities/iplatform.py
+++ b/idmtools_core/idmtools/entities/iplatform.py
@@ -347,7 +347,7 @@ class IPlatform(IItem, CacheEnabled, metaclass=ABCMeta):
 
         Args:
             platform_item: Child item
-            raw: Return a platform item if True, an idm-tools entity if false
+            raw: Return a platform item if True, an idmtools entity if false
             **kwargs: Additional platform specific parameters
 
         Returns:

--- a/idmtools_core/tests/idmtools.ini
+++ b/idmtools_core/tests/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_platform_comps/idmtools_platform_comps/plugin_info.py
+++ b/idmtools_platform_comps/idmtools_platform_comps/plugin_info.py
@@ -33,7 +33,7 @@ class COMPSPlatformSpecification(PlatformSpecification):
 
     @get_description_impl
     def get_description(self) -> str:
-        return "Provides access to the COMPS Platform to IDM-Tools"
+        return "Provides access to the COMPS Platform to idmtools"
 
     @get_platform_impl
     def get(self, **configuration) -> COMPSPlatform:
@@ -60,7 +60,7 @@ class SSMTPlatformSpecification(PlatformSpecification):
 
     @get_description_impl
     def get_description(self) -> str:
-        return "Provides access to the COMPS Platform to IDM-Tools"
+        return "Provides access to the COMPS Platform to idmtools"
 
     @get_platform_impl
     def get(self, **configuration) -> COMPSPlatform:

--- a/idmtools_platform_comps/setup.py
+++ b/idmtools_platform_comps/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""The setup script for the idmtools_platform_comps platform, for users who use the COMPS platform for IDM-Tools."""
+"""The setup script for the idmtools_platform_comps platform, for users who use the COMPS platform for idmtools."""
 from setuptools import setup, find_packages
 
 with open('README.md', encoding='utf-8') as readme_file:

--- a/idmtools_platform_comps/tests/idmtools.ini
+++ b/idmtools_platform_comps/tests/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_platform_comps/tests/inputs/idmtools.ini
+++ b/idmtools_platform_comps/tests/inputs/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_platform_comps/tests/test_ssmt/idmtools.ini
+++ b/idmtools_platform_comps/tests/test_ssmt/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multi-threaded activities
+# Number of threads idmtools will use for analysis and other multi-threaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_platform_local/setup.py
+++ b/idmtools_platform_local/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """The setup script for the idmtools_platform_local module, which provides ability to run models locally using docker
-containers to IDM-Tools."""
+containers to idmtools."""
 import sys
 
 from setuptools import setup, find_packages

--- a/idmtools_platform_local/tests/idmtools.ini
+++ b/idmtools_platform_local/tests/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multithreaded activities
+# Number of threads idmtools will use for analysis and other multithreaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_platform_slurm/idmtools_platform_slurm/plugin_info.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/plugin_info.py
@@ -10,7 +10,7 @@ SLURM_EXAMPLE_CONFIG = """
 [Slurm]
 # mode of operation. Options are ssh or local
 # SSH would mean you remotely connect to the head node to submit jobs to slurm(and use that to transfer files as well)
-# Local is when you install idm-tools on the head node and run from there
+# Local is when you install idmtools on the head node and run from there
 mode = ssh
 job_directory = /data
 # values on ALL or END. 

--- a/idmtools_platform_slurm/tests/idmtools.ini
+++ b/idmtools_platform_slurm/tests/idmtools.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multithreaded activities
+# Number of threads idmtools will use for analysis and other multithreaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_test/idmtools_test/inputs/configuration/idmtools_test.ini
+++ b/idmtools_test/idmtools_test/inputs/configuration/idmtools_test.ini
@@ -1,5 +1,5 @@
 [COMMON]
-# Number of threads idm-tools will use for analysis and other multithreaded activities
+# Number of threads idmtools will use for analysis and other multithreaded activities
 max_threads = 16
 
 # How many simulations per threads during simulation creation

--- a/idmtools_test/setup.py
+++ b/idmtools_test/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""The setup script for the idmtools_test module to run extended tests and provide demo date for IDM-Tools tests."""
+"""The setup script for the idmtools_test module to run extended tests and provide demo date for idmtools tests."""
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
This change updates the name of the product in the docs and in some code comments. Docs build fine. I found several more instances of "IDM-Tools" in the CLI files and in metadata for some egg-info files that I didn't touch and should be cleaned up by someone who knows more about those files and won't break anything. 