### PR TITLE
Change to python3

### DIFF
--- a/examples/ssmt/generic_ssmt/run_ssmt_analysis.py
+++ b/examples/ssmt/generic_ssmt/run_ssmt_analysis.py
@@ -3,7 +3,7 @@ from idmtools.core.platform_factory import Platform
 from idmtools_platform_comps.ssmt_work_items.comps_workitems import SSMTWorkItem
 
 wi_name = "SSMT Analysis generic 1"
-command = "python run_analysis.py"
+command = "python3 run_analysis.py"
 
 if __name__ == "__main__":
     platform = Platform('BELEGOST')

--- a/examples/ssmt/hello_world/run_ssmt_task.py
+++ b/examples/ssmt/hello_world/run_ssmt_task.py
@@ -3,7 +3,7 @@ from idmtools.core.platform_factory import Platform
 from idmtools_platform_comps.ssmt_work_items.comps_workitems import SSMTWorkItem
 
 wi_name = "SSMT Hello 1"
-command = "python hello.py"
+command = "python3 hello.py"
 tags = {'test': 123}
 
 if __name__ == "__main__":

--- a/examples/ssmt/more_mutiple_analyzers/multiple_analyzers_with_SSMTWorkItem.py
+++ b/examples/ssmt/more_mutiple_analyzers/multiple_analyzers_with_SSMTWorkItem.py
@@ -5,7 +5,7 @@ from idmtools.core.platform_factory import Platform
 from idmtools_platform_comps.ssmt_work_items.comps_workitems import SSMTWorkItem
 
 # run command in comps's workitem
-command = "python Assets/analyzer_file.py"
+command = "python3 Assets/analyzer_file.py"
 # load everything including analyzers from local 'analyzers' dir to comps's Assets dir in workitem
 
 if __name__ == "__main__":

--- a/examples/ssmt/simple_assets/run_ssmt_python.py
+++ b/examples/ssmt/simple_assets/run_ssmt_python.py
@@ -3,7 +3,7 @@ from idmtools.core.platform_factory import Platform
 from idmtools_platform_comps.ssmt_work_items.comps_workitems import SSMTWorkItem
 
 wi_name = "SSMT AssetCollection Hello 1"
-command = "python Assets/Hello_model.py"
+command = "python3 Assets/Hello_model.py"
 
 if __name__ == "__main__":
     platform = Platform('BELEGOST')

--- a/idmtools_core/idmtools/analysis/platform_anaylsis.py
+++ b/idmtools_core/idmtools/analysis/platform_anaylsis.py
@@ -114,7 +114,7 @@ class PlatformAnalysis:
         if self.wrapper_shell_script:
             self.additional_files.add_or_replace_asset(self.wrapper_shell_script)
             command += f'{self.shell_script_binary} {os.path.basename(self.wrapper_shell_script)} '
-        command += "python platform_analysis_bootstrap.py"
+        command += "python3 platform_analysis_bootstrap.py"
         # Add the experiments
         command += f' --experiment-ids {",".join(self.experiment_ids)}'
         # Add the analyzers

--- a/idmtools_core/tests/test_configuration.py
+++ b/idmtools_core/tests/test_configuration.py
@@ -106,7 +106,7 @@ class TestConfig(ITestWithPersistence):
     def test_non_standard_name_fails_when_not_found(self):
         with self.assertRaises(ValueError) as err:
             IdmConfigParser(file_name="idmtools_does_not_exist.ini")
-        self.assertEqual(err.exception.args[0], "The configuration file ./idmtools_does_not_exist.ini was not found!")
+        self.assertIn("idmtools_does_not_exist.ini was not found!", err.exception.args[0])
 
     @skip_if_global_configuration_is_enabled
     @run_in_temp_dir

--- a/idmtools_core/tests/test_platform_analysis.py
+++ b/idmtools_core/tests/test_platform_analysis.py
@@ -16,7 +16,7 @@ class TestPlatformAnalysis(TestCase):
         platform_analysis = PlatformAnalysis(platform=platform, experiment_ids=['3f46b433-1c8b-400f-a0df-f252c8a47329'], analyzers=[SampleAnalyzer])
         command = platform_analysis._prep_analyze()
 
-        self.assertEqual(command, 'python platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --block Test')
+        self.assertEqual(command, 'python3 platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --block Test')
 
         self.assertEqual(len(platform_analysis.additional_files), 4)
         asset_names = [f.filename for f in platform_analysis.additional_files]
@@ -34,7 +34,7 @@ class TestPlatformAnalysis(TestCase):
         platform_analysis = PlatformAnalysis(platform=platform, experiment_ids=['3f46b433-1c8b-400f-a0df-f252c8a47329'], analyzers=[SampleAnalyzer], verbose=True)
         command = platform_analysis._prep_analyze()
 
-        self.assertEqual(command, 'python platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --block Test --verbose')
+        self.assertEqual(command, 'python3 platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --block Test --verbose')
 
     def test_wrapper_command(self):
         f = tempfile.NamedTemporaryFile(suffix='.sh', mode='w', delete=False)
@@ -43,7 +43,7 @@ class TestPlatformAnalysis(TestCase):
         platform_analysis = PlatformAnalysis(platform=platform, experiment_ids=['3f46b433-1c8b-400f-a0df-f252c8a47329'], analyzers=[SampleAnalyzer], wrapper_shell_script=f.name, verbose=True)
         command = platform_analysis._prep_analyze()
 
-        self.assertEqual(command, f'/bin/bash {os.path.basename(f.name)} python platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --block Test --verbose')
+        self.assertEqual(command, f'/bin/bash {os.path.basename(f.name)} python3 platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --block Test --verbose')
 
     def test_pre_run_pickle(self):
         platform = Platform('Test')
@@ -53,7 +53,7 @@ class TestPlatformAnalysis(TestCase):
         platform_analysis = PlatformAnalysis(platform=platform, experiment_ids=['3f46b433-1c8b-400f-a0df-f252c8a47329'], analyzers=[SampleAnalyzer], pre_run_func=pre_run)
         command = platform_analysis._prep_analyze()
 
-        self.assertEqual(command, 'python platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --pre-run-func pre_run --block Test')
+        self.assertEqual(command, 'python3 platform_analysis_bootstrap.py --experiment-ids 3f46b433-1c8b-400f-a0df-f252c8a47329 --analyzers download_analyzer.DownloadAnalyzer --pre-run-func pre_run --block Test')
         asset_names = [f.filename for f in platform_analysis.additional_files]
         self.assertIn("platform_analysis_bootstrap.py", asset_names)
         self.assertIn("download_analyzer.py", asset_names)

--- a/idmtools_models/README.md
+++ b/idmtools_models/README.md
@@ -27,4 +27,3 @@ test        -   Run All tests
 coverage    -   Run tests and generate coverage report that is shown in browser
 ```
 On Windows, you can use `pymake` instead of `make`
-

--- a/idmtools_platform_comps/idmtools_platform_comps/utils/python_requirements_ac/requirements_to_asset_collection.py
+++ b/idmtools_platform_comps/idmtools_platform_comps/utils/python_requirements_ac/requirements_to_asset_collection.py
@@ -209,7 +209,7 @@ class RequirementsToAssetCollection:
             logger.debug(f'md5_str: {md5_str}')
 
         wi_name = "wi to create ac"
-        command = f"python {MODEL_CREATE_AC} {exp_id} {md5_str} {self.platform.endpoint} {self._os_target}"
+        command = f"python3 {MODEL_CREATE_AC} {exp_id} {md5_str} {self.platform.endpoint} {self._os_target}"
         tags = {MD5_KEY.format(self._os_target): self.checksum}
 
         user_logger.info("Converting Python Packages to an Asset Collection. This may take some time for large dependency lists")

--- a/idmtools_platform_comps/tests/inputs/run_multiple_analyzers.py
+++ b/idmtools_platform_comps/tests/inputs/run_multiple_analyzers.py
@@ -1,6 +1,6 @@
 """
 This script is to create AnalyzerManager and do analyzer.
-If you want to run it locally, just run as "python run_analysis.py expid"
+If you want to run it locally, just run as "python3 run_analysis.py expid"
 If you want to run it from ssmt, you will call this file from run_ssmt_analysis.py as example
 """
 import os

--- a/idmtools_platform_comps/tests/test_ssmt/test_ssmt_platformanalysis.py
+++ b/idmtools_platform_comps/tests/test_ssmt/test_ssmt_platformanalysis.py
@@ -90,9 +90,9 @@ class TestPlatformAnalysis(ITestWithPersistence):
         self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
         execution = worker_order['Execution']
         if test_with_new_code:
-            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers simple_analyzer.SimpleAnalyzer --block {platform._config_block}")
+            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python3 platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers simple_analyzer.SimpleAnalyzer --block {platform._config_block}")
         else:
-            self.assertEqual(execution['Command'], f"python platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers simple_analyzer.SimpleAnalyzer --block {platform._config_block}")
+            self.assertEqual(execution['Command'], f"python3 platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers simple_analyzer.SimpleAnalyzer --block {platform._config_block}")
 
     @pytest.mark.smoke
     def test_ssmt_workitem_python_simple_analyzer_using_alias(self):
@@ -132,9 +132,9 @@ class TestPlatformAnalysis(ITestWithPersistence):
         self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
         execution = worker_order['Execution']
         if test_with_new_code:
-            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers csv_analyzer.CSVAnalyzer --block COMPS2")
+            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python3 platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers csv_analyzer.CSVAnalyzer --block COMPS2")
         else:
-            self.assertEqual(execution['Command'], f"python platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers csv_analyzer.CSVAnalyzer --block COMPS2")
+            self.assertEqual(execution['Command'], f"python3 platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers csv_analyzer.CSVAnalyzer --block COMPS2")
 
     @pytest.mark.comps
     def test_ssmt_seir_model_analysis(self):
@@ -166,9 +166,9 @@ class TestPlatformAnalysis(ITestWithPersistence):
         self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
         execution = worker_order['Execution']
         if test_with_new_code:
-            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python platform_analysis_bootstrap.py --experiment-ids {exp_id} --analyzers infectiousness_csv_analyzer.InfectiousnessCSVAnalyzer,node_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
+            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python3 platform_analysis_bootstrap.py --experiment-ids {exp_id} --analyzers infectiousness_csv_analyzer.InfectiousnessCSVAnalyzer,node_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
         else:
-            self.assertEqual(execution['Command'], f"python platform_analysis_bootstrap.py --experiment-ids {exp_id} --analyzers infectiousness_csv_analyzer.InfectiousnessCSVAnalyzer,node_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
+            self.assertEqual(execution['Command'], f"python3 platform_analysis_bootstrap.py --experiment-ids {exp_id} --analyzers infectiousness_csv_analyzer.InfectiousnessCSVAnalyzer,node_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
 
     @pytest.mark.comps
     def test_ssmt_seir_model_analysis_single_script(self):
@@ -204,9 +204,9 @@ class TestPlatformAnalysis(ITestWithPersistence):
         self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
         execution = worker_order['Execution']
         if test_with_new_code:
-            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python platform_analysis_bootstrap.py --experiment-ids {exp_id} --analyzers custom_csv_analyzer.InfectiousnessCSVAnalyzer,custom_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
+            self.assertEqual(execution['Command'], f"/bin/bash {os.path.basename(wrapper)} python3 platform_analysis_bootstrap.py --experiment-ids {exp_id} --analyzers custom_csv_analyzer.InfectiousnessCSVAnalyzer,custom_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
         else:
-            self.assertEqual(execution['Command'], "python platform_analysis_bootstrap.py --experiment-ids " + exp_id + " --analyzers custom_csv_analyzer.InfectiousnessCSVAnalyzer,custom_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
+            self.assertEqual(execution['Command'], "python3 platform_analysis_bootstrap.py --experiment-ids " + exp_id + " --analyzers custom_csv_analyzer.InfectiousnessCSVAnalyzer,custom_csv_analyzer.NodeCSVAnalyzer --block COMPS2")
 
     @pytest.mark.skipif(not os.path.exists(comps_local_package) or not os.path.exists(core_local_package), reason=f"To run this, you need both {comps_local_package} and {core_local_package}. You can create these files by running pymake dist in each package directory")
     def test_using_newest_code(self):
@@ -242,7 +242,7 @@ class TestPlatformAnalysis(ITestWithPersistence):
         worker_order = json.load(open(os.path.join(file_path, "WorkOrder.json"), 'r'))
         self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
         execution = worker_order['Execution']
-        self.assertEqual(execution['Command'], f'/bin/bash {os.path.basename(wrapper)} python platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers simple_analyzer.SimpleAnalyzer --pre-run-func pre_load_func --block COMPS2')
+        self.assertEqual(execution['Command'], f'/bin/bash {os.path.basename(wrapper)} python3 platform_analysis_bootstrap.py --experiment-ids {experiment_id} --analyzers simple_analyzer.SimpleAnalyzer --pre-run-func pre_load_func --block COMPS2')
 
         with open(os.path.join(file_path, "stdout.txt"), 'r') as fin:
             stdout_contents = fin.read()

--- a/idmtools_platform_comps/tests/test_ssmt/test_ssmt_workitem.py
+++ b/idmtools_platform_comps/tests/test_ssmt/test_ssmt_workitem.py
@@ -30,7 +30,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
     # "hello.py" will run in comps's workitem worker like running it in local:
     # python hello.py
     def test_ssmt_workitem_python(self):
-        command = "python hello.py"
+        command = "python3 hello.py"
         user_files = AssetCollection()
         user_files.add_asset(os.path.join(self.input_file_path, "hello.py"))
 
@@ -52,7 +52,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
         self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
         execution = worker_order['Execution']
         self.assertEqual(execution['Command'],
-                         "python hello.py")
+                         "python3 hello.py")
 
     # test using SSMTWormItem to run PopulationAnalyzer in comps's SSMT DockerWorker
     @pytest.mark.smoke
@@ -69,7 +69,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
 
         experiment_id = "8bb8ae8f-793c-ea11-a2be-f0921c167861"  # COMPS2 exp
         # experiment_id = "18553481-1f42-ea11-941b-0050569e0ef3"  # idmtvapp17 exp
-        command = "python Assets/run_population_analyzer.py " + experiment_id
+        command = "python3 Assets/run_population_analyzer.py " + experiment_id
         wi = SSMTWorkItem(item_name=self.case_name, command=command, assets=asset_files, transient_assets=transient_assets, tags=self.tags)
         wi.run(wait_on_done=True)
 
@@ -88,7 +88,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
             print(worker_order)
             self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
             execution = worker_order['Execution']
-            self.assertEqual(execution['Command'], "python Assets/run_population_analyzer.py " + experiment_id)
+            self.assertEqual(execution['Command'], "python3 Assets/run_population_analyzer.py " + experiment_id)
 
     # test using SSMTWormItem to run multiple analyzers in comps's SSMT DockerWorker
     def test_ssmt_workitem_multiple_analyzers(self):
@@ -107,7 +107,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
 
         experiment_id = "8bb8ae8f-793c-ea11-a2be-f0921c167861"  # COMPS2 exp
         # experiment_id = "18553481-1f42-ea11-941b-0050569e0ef3"  # idmtvapp17 exp
-        command = "python run_multiple_analyzers.py " + experiment_id
+        command = "python3 run_multiple_analyzers.py " + experiment_id
         wi = SSMTWorkItem(item_name=self.case_name, command=command, transient_assets=transient_assets, tags=self.tags)
         wi.run(wait_on_done=True)
 
@@ -130,7 +130,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
             print(worker_order)
             self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
             execution = worker_order['Execution']
-            self.assertEqual(execution['Command'], "python run_multiple_analyzers.py " + experiment_id)
+            self.assertEqual(execution['Command'], "python3 run_multiple_analyzers.py " + experiment_id)
 
     # test using SSMTWormItem to run multiple experiments in comps's SSMT DockerWorker
     @pytest.mark.skip("need emodpy")
@@ -150,7 +150,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
         transient_assets = AssetCollection()
         transient_assets.add_asset(os.path.join(self.input_file_path, "idmtools.ini"))
 
-        command = "python Assets/run_multiple_exps.py " + exp_id1 + " " + exp_id2
+        command = "python3 Assets/run_multiple_exps.py " + exp_id1 + " " + exp_id2
         wi = SSMTWorkItem(name=self.case_name, command=command, assets=asset_files, transient_assets=transient_assets, tags=self.tags)
         wi.run(wait_on_done=True)
 
@@ -169,7 +169,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
             print(worker_order)
             self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
             execution = worker_order['Execution']
-            self.assertEqual(execution['Command'], "python Assets/run_multiple_exps.py " + exp_id1 + " " + exp_id2)
+            self.assertEqual(execution['Command'], "python3 Assets/run_multiple_exps.py " + exp_id1 + " " + exp_id2)
 
     @pytest.mark.comps
     def test_ssmt_seir_model_analysis_single_script(self):
@@ -180,7 +180,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
         transient_assets.add_asset(os.path.join(self.input_file_path, 'run_multiple_analyzers_single_script.py'))
         transient_assets.add_asset(os.path.join(self.input_file_path, 'idmtools.ini'))
 
-        command = "python run_multiple_analyzers_single_script.py " + exp_id
+        command = "python3 run_multiple_analyzers_single_script.py " + exp_id
         wi = SSMTWorkItem(name=self.case_name, command=command, transient_assets=transient_assets, tags=self.tags)
         wi.run(True, platform=self.platform)
 
@@ -202,7 +202,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
             print(worker_order)
             self.assertEqual(worker_order['WorkItem_Type'], "DockerWorker")
             execution = worker_order['Execution']
-            self.assertEqual(execution['Command'], "python run_multiple_analyzers_single_script.py "+ exp_id)
+            self.assertEqual(execution['Command'], "python3 run_multiple_analyzers_single_script.py "+ exp_id)
 
     def test_get_files(self):
         wi_id = '5e2fc03d-2162-ea11-a2bf-f0921c167862'  # comps2 wi_id
@@ -259,7 +259,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
 
         experiment_id = '9311af40-1337-ea11-a2be-f0921c167861'  # staging comps2 exp id
         # experiment_id = 'de07f612-69ed-ea11-941f-0050569e0ef3'  # idmtvapp17
-        command = "python Assets/run_csv_analyzer.py " + experiment_id
+        command = "python3 Assets/run_csv_analyzer.py " + experiment_id
         wi = SSMTWorkItem(name=self.case_name, command=command, assets=asset_files, transient_assets=transient_assets, tags=self.tags)
         wi.run(wait_on_done=True)
         local_output_path = "output"
@@ -309,7 +309,7 @@ class TestSSMTWorkItem(ITestWithPersistence):
         self.assertEqual(len(wi.transient_assets), 0)
 
     def test_workitem_task(self):
-        command = "python hello.py"
+        command = "python3 hello.py"
         task = CommandTask(command=command, transient_assets=AssetCollection([os.path.join(self.input_file_path, "hello.py")]))
         wi = SSMTWorkItem(task=task, name=self.case_name, tags=self.tags)
         wi.run(wait_on_done=True)


### PR DESCRIPTION
Change python to python3 in ssmt related examples and tests
as well as in idmtools_core/idmtools/analysis/platform_anaylsis.py and idmtools_platform_comps/idmtools_platform_comps/utils/python_requirements_ac/requirements_to_asset_collection.py
