### PR TITLE
added flag to remove empty 'module contents' heading from API ref docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -54,19 +54,19 @@ clean:
 generate-api:
 	-rm modules.rst
 	-rm idmtools_index.rst
-	sphinx-apidoc -f -e -o . ../idmtools_core/idmtools
+	sphinx-apidoc -f -e -M -o . ../idmtools_core/idmtools
 	mv modules.rst idmtools_index.rst
 
 	-rm idmtools_models_index.rst
-	sphinx-apidoc -f -e -o . ../idmtools_models/idmtools_models
+	sphinx-apidoc -f -e -M -o . ../idmtools_models/idmtools_models
 	mv modules.rst idmtools_models_index.rst
 
 	-rm idmtools_platform_comps_index.rst
-	sphinx-apidoc -f -e -o . ../idmtools_platform_comps/idmtools_platform_comps
+	sphinx-apidoc -f -e -M -o . ../idmtools_platform_comps/idmtools_platform_comps
 	mv modules.rst idmtools_platform_comps_index.rst
 
 	-rm idmtools_platform_local_index.rst
-	SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance,ignore-module-all sphinx-apidoc -f -e -o . ../idmtools_platform_local/idmtools_platform_local
+	SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance,ignore-module-all sphinx-apidoc -f -e -M -o . ../idmtools_platform_local/idmtools_platform_local
 	mv modules.rst idmtools_platform_local_index.rst
 	rm -rf idmtools_platform_local.internals.tasks.*.rst
 	cp idmtools_platform_local.internals.tasks.template idmtools_platform_local.internals.tasks.rst

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -78,20 +78,20 @@ if "%1" == "generate-api" (
 	set SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance,ignore-module-all
 	del modules.rst >nul 2>&1
 	del idmtools_index.rst >nul 2>&1
-    sphinx-apidoc -f -e -o . ../idmtools_core/idmtools
+    sphinx-apidoc -f -e -M -o . ../idmtools_core/idmtools
 	REN modules.rst idmtools_index.rst
 	del modules.rst >nul 2>&1
 	del idmtools_models_index.rst >nul 2>&1
-	sphinx-apidoc -f -e -o . ../idmtools_models/idmtools_models
+	sphinx-apidoc -f -e -M -o . ../idmtools_models/idmtools_models
 	REN modules.rst idmtools_models_index.rst
 
 	del idmtools_platform_comps_index.rst >nul 2>&1
-	sphinx-apidoc -f -e -o . ../idmtools_platform_comps/idmtools_platform_comps
+	sphinx-apidoc -f -e -M -o . ../idmtools_platform_comps/idmtools_platform_comps
 	REN modules.rst idmtools_platform_comps_index.rst
 
 	del idmtools_platform_local_index.rst >nul 2>&1
 	DEL /Q /F /S "*.tmp" >nul 2>&1
-	sphinx-apidoc -f -e -o . ../idmtools_platform_local/idmtools_platform_local
+	sphinx-apidoc -f -e -M -o . ../idmtools_platform_local/idmtools_platform_local
 	REN modules.rst idmtools_platform_local_index.rst
 	DEL /Q /F /S "idmtools_platform_local.internals.tasks.*.rst" >nul 2>&1
 	COPY idmtools_platform_local.internals.tasks.template idmtools_platform_local.internals.tasks.rst


### PR DESCRIPTION
I thought I submitted this fix earlier, but I guess I missed it. This flag removes the "Module contents" section that's empty and generated for each module. 
<img width="431" alt="module_contents" src="https://user-images.githubusercontent.com/20909236/97062454-337bf880-1558-11eb-8ceb-eecd7fd1aacb.png">
