### PR TITLE
hotfix  to exclude numpy 1.19.4 (1.6.x branch)

### DIFF
--- a/idmtools_core/requirements.txt
+++ b/idmtools_core/requirements.txt
@@ -3,7 +3,7 @@ coloredlogs~=14.0
 diskcache==5.0.3
 humanfriendly~=8.2
 more-itertools~=8.5.0
-numpy==1.19.3
+numpy!=1.19.4
 pandas==1.1.3
 pipreqs==0.4.10
 pluggy~=0.13.1


### PR DESCRIPTION
Fixed https://github.com/InstituteforDiseaseModeling/idmtools/issues/1293