### PR TITLE
Fix ac recursive error issue (for release-1.6.x branch) 

### DIFF
--- a/idmtools_core/idmtools/assets/asset_collection.py
+++ b/idmtools_core/idmtools/assets/asset_collection.py
@@ -181,7 +181,7 @@ class AssetCollection(IEntity):
         if self.platform_id:
             if error:
                 raise ValueError(
-                    f"You cannot modify an already provisioned Asset Collection. If you want to modify an existing AssetCollection see the recipe {get_doc_base_url()}cookbook/asset_collections.html#modifying-asset-collection")
+                    f"You cannot modify an already provisioned Asset Collection. If you want to modify an existing AssetCollection see the recipe {get_doc_base_url()}cookbook/assets.html#modifying-asset-collection")
             return False
         return True
 

--- a/idmtools_platform_comps/idmtools_platform_comps/comps_operations/asset_collection_operations.py
+++ b/idmtools_platform_comps/idmtools_platform_comps/comps_operations/asset_collection_operations.py
@@ -128,7 +128,7 @@ class CompsPlatformAssetCollectionOperations(IPlatformAssetCollectionOperations)
             ac2.save()
             ac = ac2
         asset_collection.uid = ac.id
-        asset_collection._platform_object = asset_collection
+        asset_collection._platform_object = ac
         asset_collection.platform = self.platform
         asset_collection.platform_id = self.platform.uid
         return ac

--- a/idmtools_platform_comps/idmtools_platform_comps/comps_operations/experiment_operations.py
+++ b/idmtools_platform_comps/idmtools_platform_comps/comps_operations/experiment_operations.py
@@ -169,7 +169,7 @@ class CompsPlatformExperimentOperations(IPlatformExperimentOperations):
                 # trigger precreate just to be sure
                 if not regather_common_assets:
                     user_logger.warning(
-                        f"Not gathering common assets again since experiment exists on platform. If you need to add additional common assets, see {get_doc_base_url()}cookbook/asset_collections.html#modifying-asset-collection")
+                        f"Not gathering common assets again since experiment exists on platform. If you need to add additional common assets, see {get_doc_base_url()}cookbook/assets.html#modifying-asset-collection")
                 experiment.pre_creation(self.platform, gather_assets=regather_common_assets)
                 self.send_assets(experiment)
         return experiment


### PR DESCRIPTION
This PR aims to address the following issues:

- #1303: RecursionError for print AssetCollection after create_items
- #1302: cookbook link for modify modifying-asset-collection is wrong