### PR TITLE
fix numpy version for idmtools-test package (release-1.6.x)

### DIFF
--- a/idmtools_test/requirements.txt
+++ b/idmtools_test/requirements.txt
@@ -10,3 +10,4 @@ flask_restful~=0.3.8
 Flask-SQLAlchemy~=2.4.4
 matplotlib~=3.3.3
 Werkzeug==1.0.1
+numpy!=1.19.4


### PR DESCRIPTION
idmtools-test package will install numpy 1.19.4 as some other package's dependency which will failed in windows. 
Force to not install 1.19.4 numpy