### PR TITLE
Api links for "Add to asset collection" and "Assetize outputs"

### DIFF
--- a/docs/platforms/comps/add_2ac.rst
+++ b/docs/platforms/comps/add_2ac.rst
@@ -15,18 +15,18 @@ There are two primary ways of adding assets (experiment and task):
 Add assets to experiment
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are multiple ways of adding to :py:class:`Experiment<idmtools.entities.experiment.Experiment>`:
+There are multiple ways of adding to :py:class:`~idmtools.entities.experiment.Experiment`:
 
 * Add directory to experiment/workitem::
 
     experiment.assets.add_directory(assets_directory=os.path.join("inputs", "python_model_with_deps", "Assets"))
 
-* Add list of :py:class:`Asset<idmtools.assets.asset.Asset>` or :py:class:`AssetCollection<idmtools.assets.asset_collection.AssetCollection>` to :py:class:`Experiment<idmtools.entities.experiment.Experiment>`::
+* Add list of :py:class:`~idmtools.assets.asset.Asset` or :py:class:`~idmtools.assets.asset_collection.AssetCollection` to :py:class:`~idmtools.entities.experiment.Experiment`::
 
     ac = AssetCollection.from_directory(assets_directory=os.path.abspath(os.path.join(COMMON_INPUT_PATH, "assets", collections")))
     experiment.add_assets(ac)
 
-* Add file as asset to :py:class:`Experiment<idmtools.entities.experiment.Experiment>`::
+* Add file as asset to :py:class:`~idmtools.entities.experiment.Experiment`::
 
     experiment.add_asset(os.path.join("inputs", "scheduling", "commandline_model.py"))
 
@@ -40,7 +40,7 @@ There are multiple ways of adding via task:
     task.common_assets.add_asset(os.path.join(INPUT_PATH, os_type, "bin", "schema.json"))
     task.transient_assets.add_asset(os.path.join(INPUT_PATH, "campaign_template.json"))
 
-* Add list of :py:class:`Asset<idmtools.assets.asset.Asset>` or :py:class:`AssetCollection<idmtools.assets.asset_collection.AssetCollection>` to task::
+* Add list of :py:class:`~idmtools.assets.asset.Asset` or :py:class:`~idmtools.assets.asset_collection.AssetCollection` to task::
 
     task.common_assets.add_assets(AssetCollection.from_id_file("covasim.id"))
 

--- a/docs/platforms/comps/assetize_output.rst
+++ b/docs/platforms/comps/assetize_output.rst
@@ -1,6 +1,6 @@
 .. _Assetize Outputs:
 
-Assetize Outputs
+Assetize outputs
 ================
 
 Assetizing outputs allows you to create an :py:class:`AssetCollection<idmtools.assets.asset_collection.AssetCollection>` from the outputs of a previous :py:class:`Experiment<idmtools.entities.experiment.Experiment>`,
@@ -8,15 +8,17 @@ Assetizing outputs allows you to create an :py:class:`AssetCollection<idmtools.a
 For example, three simulations and an asset collection, or an experiment and a workitem. :py:class:`AssetizeOutput<idmtools_platform_comps.utils.assetize_output.assetize_output.AssetizeOutput>` is implemented
 as a workitem that depends on other items to complete before running.
 
+Assetized outputs are available on |COMPS_s| in the :term:`asset collection` for the associated workitem.
+
 Assetize outputs using glob patterns to select or deselect files. See https://docs.python.org/3/library/glob.html for details on glob patterns.
-The default configuration is set to assetize all outputs, "**" pattern, and exclude the "StdOut.txt", "StdErr.txt", and "WorkOrder.json" files.
+The default configuration is set to assetize all outputs, "**" pattern, and exclude the ".log", "StdOut.txt", "StdErr.txt", and "WorkOrder.json" files.
 
 You can see a list of files that will be assetized without assetizing them by using the dry_run parameter. The file
 list will be in the output of the workitem.
 
 See the :ref:`Cookbook <Cookbook Assetize Outputs>` for examples of assetizing outputs.
 
-Also review the class details :py:class:`AssetizeOutput<idmtools_platform_comps.utils.assetize_output.assetize_output.AssetizeOutput>`
+Also review the class details :py:class:`~idmtools_platform_comps.utils.assetize_output.assetize_output.AssetizeOutput`
 
 You can also run this command from the CLI. For details, see :ref:`COMPS CLI reference<COMPS CLI>`.
 


### PR DESCRIPTION
@devclinton, @shchen-idmod, I've started adding api reference links to the idmtools doc set - making sure it is current with new/updated content in api ref. I'm hoping to first receive your feedback on what I've done so far before I continue much further. For example, looking at the case changes I made and links I provided - one in particular being 'workitem' and the referenced classes. I can then use your feedback/input as a model going forward. Thanks!

<img width="745" alt="Add to asset collection" src="https://user-images.githubusercontent.com/35471720/120726400-d69cd500-c48c-11eb-94ee-55c3128c6604.PNG">

<img width="755" alt="Assetize outputs" src="https://user-images.githubusercontent.com/35471720/120726411-dac8f280-c48c-11eb-9961-871517f6d57d.PNG">
  