### PR TITLE
Generate configuration using multiprocessing

### DIFF
--- a/idmtools_core/idmtools/entities/templated_simulation.py
+++ b/idmtools_core/idmtools/entities/templated_simulation.py
@@ -21,6 +21,7 @@ import multiprocessing
 if TYPE_CHECKING:  # pragma: no cover
     from idmtools.entities.experiment import Experiment
 
+
 def create_simulation(simulation_obj, groups):
     for simulation_functions in filter(None, groups):
         simulation = copy.deepcopy(simulation_obj)
@@ -33,6 +34,7 @@ def create_simulation(simulation_obj, groups):
 
     simulation.tags.update(tags)
     return simulation
+
 
 def simulation_generator(builders, new_sim_func, additional_sims=None, batch_size=10):
     """
@@ -58,6 +60,7 @@ def simulation_generator(builders, new_sim_func, additional_sims=None, batch_siz
         yield s
 
     yield from additional_sims
+
 
 @dataclass(repr=False)
 class TemplatedSimulations:

--- a/idmtools_core/idmtools/entities/templated_simulation.py
+++ b/idmtools_core/idmtools/entities/templated_simulation.py
@@ -29,7 +29,7 @@ def create_simulation(simulation_obj, groups):
         tags = {}
 
         for func in simulation_functions:
-            new_tags = func(simulation=simulation)
+            new_tags = func(simulation=simulation)  # func changes simulation
             if new_tags:
                 tags.update(new_tags)
 

--- a/idmtools_core/idmtools/entities/templated_simulation.py
+++ b/idmtools_core/idmtools/entities/templated_simulation.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def create_simulation(simulation_obj, groups):
+    simulations = []
     for simulation_functions in filter(None, groups):
         simulation = copy.deepcopy(simulation_obj)
         tags = {}
@@ -32,8 +33,9 @@ def create_simulation(simulation_obj, groups):
             if new_tags:
                 tags.update(new_tags)
 
-    simulation.tags.update(tags)
-    return simulation
+        simulation.tags.update(tags)
+        simulations.append(simulation)
+    return simulations
 
 
 def simulation_generator(builders, new_sim_func, additional_sims=None, batch_size=10):
@@ -54,10 +56,11 @@ def simulation_generator(builders, new_sim_func, additional_sims=None, batch_siz
         additional_sims = []
     # Then the builders
     create_simulation_fct = partial(create_simulation, new_sim_func())
-    result = pool.map(create_simulation_fct, grouper(chain(*builders), batch_size))
+    results = pool.map(create_simulation_fct, grouper(chain(*builders), batch_size))
 
-    for s in result:
-        yield s
+    for result in results:
+        for r in result:
+            yield r
 
     yield from additional_sims
 


### PR DESCRIPTION
- Josh mentioned that it takes quite long to generate configuration files
- Profiling emod-api didn't really show a way to reduce processing time
- Using multiprocessing to create the configuration reduced the processing time by a factor of 3