### PR TITLE
fixed the link to the reference docs and added some info about slurm …

### DIFF
--- a/docs/platforms/platforms-slurm.rst
+++ b/docs/platforms/platforms-slurm.rst
@@ -4,9 +4,8 @@ SLURM
 The |SLURM_s| platform allows use of the |SLURM_l|. "Slurm is an open source, fault-tolerant, and highly scalable cluster management and job scheduling system for large and small Linux clusters.", as quoted from (https://slurm.schedmd.com/overview.html). For high-level architecture information about |SLURM_s|, 
 see (https://slurm.schedmd.com/quickstart.html#arch). 
 For architecure and included packages information about |IT_s| and |SLURM_s|, 
-see (https://docs.idmod.org/projects/idmtools/en/latest/reference.html).
+see (:doc:`../reference`).
 
-.. :doc:`reference` errors out as unknown document when building sphinx local files, not sure why as the file exists and is in the same directory as other working referenced files, such as basis-installation...
 
 Prerequisites
 =============

--- a/docs/platforms/platforms.rst
+++ b/docs/platforms/platforms.rst
@@ -1,5 +1,5 @@
 ===================
-Supported Platforms
+Supported platforms
 ===================
 
 |IT_s| currently supports running on the following platforms:
@@ -8,7 +8,11 @@ Supported Platforms
 
 .. include:: /reuse/comps_note.txt
 
+**SLURM**: You can also run simulations on the open-source |SLURM_s| platform for large and small Linux clusters.". For more information, see :doc:`platforms-slurm`.
+
 **Local**: You can also run simulations and analysis locally on your computer, rather than on a remote high-performance computer (HPC). For more information about these modules, see :doc:`../idmtools_platform_local_index`.
+
+If you need to use a different platform, you can also add a new platform to |IT_s| by creating a new platform plugin, as described in :doc:`platforms-plugin`. 
 
 You can use the **idmtools.ini** file to configure platform specific settings, as the following examples shows for |COMPS_s|::
 


### PR DESCRIPTION
…to the platform parent topic

Ross--the link to the reference topic needs to be relative to the RST file you are writing in, so it needed to move up a directory. FWIW, this is why we didn't use directories in the EMOD docs because the extensive content reuse made relative paths difficult to use in multiple locations. 