### PR TITLE
Add pygithub back to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx-rtd-theme==1.0.0
 sphinxcontrib-napoleon~=0.7
 sphinxcontrib-programoutput~=0.17
 sphinx~=4.5.0
+pygithub~=1.55


### PR DESCRIPTION
I previously removed pygithub because it was causing doc build errors, but the issue on Read the Docs seems to be resolved so adding it back to make it easier to generate the changelog. 