### PR TITLE
Update readthedocs.yml to remove python.version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,9 +28,8 @@ formats:
   - htmlzip
   - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally set the requirements required to build your docs (set Python version in build section)
 python:
-  version: 3.8
   install:
     - requirements: dev_scripts/package_requirements.txt
     - requirements: docs/requirements.txt


### PR DESCRIPTION
According to RTD docs, this is deprecated in favor of build.tools.python and you cannot use both in the same YAML file. https://docs.readthedocs.io/en/latest/config-file/v2.html#python-version