### PR TITLE
Handle Slurm MaxArraySize

### DIFF
--- a/examples/native_slurm/python_sims_array_size.py
+++ b/examples/native_slurm/python_sims_array_size.py
@@ -1,0 +1,86 @@
+# Simple python simulation running native slurm cluster. This example is to run python script(model3.py) in slurm cluster
+# which doing simple add() caculation function with 2 sweep parameters as add(a,b)=a+b). The function result will be
+# printed to stdout.txt file and output/result.txt file in each simulation folder.
+# Path for simulation in cluster machine: /home/username/example/suite_id/experiment_id/simulation_id
+import os
+import sys
+from functools import partial
+from typing import Any, Dict
+
+from idmtools.builders import SimulationBuilder
+from idmtools.core.platform_factory import Platform
+from idmtools.entities import Suite
+from idmtools.entities.experiment import Experiment
+from idmtools.entities.simulation import Simulation
+from idmtools.entities.templated_simulation import TemplatedSimulations
+from idmtools_models.python.json_python_task import JSONConfiguredPythonTask
+
+from idmtools_test import COMMON_INPUT_PATH
+
+# job dir should be /home/username/example
+job_directory = os.path.join(os.path.expanduser('~'), "example")
+# Define Slurm Platform. Note, this code can only run in slurm cluster.
+platform = Platform('SLURM_LOCAL', job_directory=job_directory)
+
+#Define our base task. Normally, you want to do set any assets/configurations you want across the
+# all the different Simulations we are going to build for our experiment. Here we set c to 0 since we do not want to
+# sweep it
+task = JSONConfiguredPythonTask(script_path=os.path.join(COMMON_INPUT_PATH, "python", "model3.py"),
+                                envelope="parameters", parameters=(dict(c=0)))
+task.python_path = "python3"
+
+# now let's use this task to create a TemplatedSimulation builder. This will build new simulations from sweep builders
+# we will define later. We can also use it to manipulate the base_task or the base_simulation
+ts = TemplatedSimulations(base_task=task)
+# We can define common metadata like tags across all the simulations using the base_simulation object
+ts.base_simulation.tags['tag1'] = 1
+
+# Since we have our templated simulation object now, let's define our sweeps
+# To do that we need to use a builder
+builder = SimulationBuilder()
+
+# Define an utility function that will update a single parameter at a
+# # time on the model and add that param/value pair as a tag on our simulation.
+def param_update(simulation: Simulation, param: str, value: Any) -> Dict[str, Any]:
+    """
+    This function is called during sweeping allowing us to pass the generated sweep values to our Task Configuration.
+
+    We always receive a Simulation object. We know that simulations all have tasks and that for our particular set
+    of simulations they will all include JSONConfiguredPythonTask. We configure the model with calls to set_parameter
+    to update the config. In addition, we can return a dictionary of tags to add to the simulations so we return
+    the output of the 'set_parameter' call since it returns the param/value pair we set
+
+    Args:
+        simulation: Simulation we are configuring
+        param: Param string passed to use
+        value: Value to set param to
+
+    Returns:
+
+    """
+    return simulation.task.set_parameter(param, value)
+
+# Let's sweep the parameter 'a' for the values 0-2
+builder.add_sweep_definition(partial(param_update, param="a"), range(30))
+
+# Let's sweep the parameter 'b' for the values 0-4
+builder.add_sweep_definition(partial(param_update, param="b"), range(5))
+ts.add_builder(builder)
+
+# Now we can create our Experiment using our template builder
+experiment = Experiment.from_template(ts, name="python example")
+# Add our own custom tag to experiment
+experiment.tags["tag1"] = 1
+# And all files from dir at COMMON_INPUT_PATH/python/Assets folder to experiment folder
+experiment.assets.add_directory(assets_directory=os.path.join(COMMON_INPUT_PATH, "python", "Assets"))
+
+# Create suite
+suite = Suite(name='Idm Suite')
+suite.update_tags({'name': 'suite_tag', 'idmtools': '123'})
+# Add experiment to the suite
+suite.add_experiment(experiment)
+# With array_batch_size=45, it should create 4 slurm jobs for this example with total 150 simulations
+experiment.run(platform=platform, wait_until_done=True, array_batch_size=45, dependency=True)
+sys.exit(0 if experiment.succeeded else -1)
+
+

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+
+get_min() {
+    if [ $1 -lt $2 ]
+    then
+        echo $1
+    else
+        echo $2
+    fi
+}
+
+# Set the total number of tasks
+total_tasks={{njobs}}
+
+# Set the number of tasks per array job
+tasks_per_job={{array_size}}
+
+# Set max running jobs
+max_jobs={{max_running_jobs}}
+
+# Submit the first array job with tasks 1-array_size
+job_id=$(sbatch --array=1-$tasks_per_job%$max_jobs sbatch.sh | awk '{print $4}')
+echo $job_id >> job_id.txt
+
+# Submit additional array jobs that depend on the first job
+for (( i=$tasks_per_job+1; i<=$total_tasks; i+=$tasks_per_job ))
+do
+    # Calculate the task range for the current array job
+    start_task=$i
+    end_task=$((i + tasks_per_job - 1))
+
+    # Get the min
+    end_task=$(get_min $end_task $total_tasks)
+
+    # Submit the array job with the current task range and a dependency on the previous job
+    {% if dependency is defined and dependency %}
+        new_job_id=$(sbatch --array=$start_task-$end_task%$max_jobs --dependency=afterok:$job_id sbatch.sh | awk '{print $4}')
+    {% else %}
+        new_job_id=$(sbatch --array=$start_task-$end_task%$max_jobs sbatch.sh | awk '{print $4}')
+    {% endif %}
+
+    # Keep the job id
+    echo $new_job_id >> job_id.txt
+
+    # Update the job ID to use as a dependency for the next array job
+    job_id=$new_job_id
+done
+
+wait

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+# Utility function
 get_min() {
     if [ $1 -lt $2 ]
     then
@@ -21,6 +21,7 @@ max_jobs={{max_running_jobs}}
 
 # Submit the first array job with tasks 1-array_size
 job_id=$(sbatch --array=1-$tasks_per_job%$max_jobs sbatch.sh | awk '{print $4}')
+# Store the job id
 echo $job_id >> job_id.txt
 
 # Submit additional array jobs that depend on the first job
@@ -40,9 +41,8 @@ do
         new_job_id=$(sbatch --array=$start_task-$end_task%$max_jobs sbatch.sh | awk '{print $4}')
     {% endif %}
 
-    # Keep the job id
+    # Store the job id
     echo $new_job_id >> job_id.txt
-
     # Update the job ID to use as a dependency for the next array job
     job_id=$new_job_id
 done

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -1,50 +1,54 @@
 #!/bin/bash
 
-# Utility function
-get_min() {
-    if [ $1 -lt $2 ]
-    then
-        echo $1
-    else
-        echo $2
-    fi
-}
-
 # Set the total number of tasks
 total_tasks={{njobs}}
 
 # Set the number of tasks per array job
-tasks_per_job={{array_size}}
+batch_size={{array_size}}
 
 # Set max running jobs
 max_jobs={{max_running_jobs}}
 
+num_batches=$((total_tasks / batch_size))
+remainder=$((total_tasks % batch_size))
+
+echo "num_batches: $num_batches"
+echo "remainder: $remainder"
+
 # Submit the first array job with tasks 1-array_size
-job_id=$(sbatch --array=1-$tasks_per_job%$max_jobs sbatch.sh | awk '{print $4}')
-# Store the job id
+job_id=$(sbatch --array=1-$batch_size%$max_jobs sbatch.sh 0 | awk '{print $4}')
 echo $job_id >> job_id.txt
 
 # Submit additional array jobs that depend on the first job
-for (( i=$tasks_per_job+1; i<=$total_tasks; i+=$tasks_per_job ))
+for (( i=1; i<$num_batches; i+=1 ))
 do
     # Calculate the task range for the current array job
-    start_task=$i
-    end_task=$((i + tasks_per_job - 1))
-
-    # Get the min
-    end_task=$(get_min $end_task $total_tasks)
+    start_task=$((i * $batch_size))
 
     # Submit the array job with the current task range and a dependency on the previous job
-    {% if dependency is defined and dependency %}
-        new_job_id=$(sbatch --array=$start_task-$end_task%$max_jobs --dependency=afterok:$job_id sbatch.sh | awk '{print $4}')
-    {% else %}
-        new_job_id=$(sbatch --array=$start_task-$end_task%$max_jobs sbatch.sh | awk '{print $4}')
-    {% endif %}
-
-    # Store the job id
+    if [ $dependency ]; then
+        new_job_id=$(sbatch --array=1-$batch_size%$max_jobs --dependency=afterok:$job_id sbatch.sh $start_task | awk '{print $4}')
+    else
+        new_job_id=$(sbatch --array=1-$batch_size%$max_jobs sbatch.sh $start_task | awk '{print $4}')
+    fi
     echo $new_job_id >> job_id.txt
+
     # Update the job ID to use as a dependency for the next array job
     job_id=$new_job_id
 done
+
+# Submit the remaining tasks as a separate batch
+if [ $remainder -gt 0 ]
+then
+    start_task=$(($num_batches * $batch_size))
+
+    # Submit the array job with the current task range and a dependency on the previous job
+    if [ $dependency ]; then
+        new_job_id=$(sbatch --array=1-$remainder%$max_jobs --dependency=afterok:$job_id sbatch.sh $start_task | awk '{print $4}')
+    else
+        new_job_id=$(sbatch --array=1-$remainder%$max_jobs sbatch.sh $start_task | awk '{print $4}')
+    fi
+    echo $new_job_id >> job_id.txt
+fi
 
 wait

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -26,11 +26,11 @@ do
     start_task=$((i * $batch_size))
 
     # Submit the array job with the current task range and a dependency on the previous job
-    if [ $dependency ]; then
+    {% if dependency is defined and dependency %}
         new_job_id=$(sbatch --array=1-$batch_size%$max_jobs --dependency=afterok:$job_id sbatch.sh $start_task | awk '{print $4}')
-    else
+    {% else %}
         new_job_id=$(sbatch --array=1-$batch_size%$max_jobs sbatch.sh $start_task | awk '{print $4}')
-    fi
+    {% endif %}
     echo $new_job_id >> job_id.txt
 
     # Update the job ID to use as a dependency for the next array job
@@ -43,11 +43,11 @@ then
     start_task=$(($num_batches * $batch_size))
 
     # Submit the array job with the current task range and a dependency on the previous job
-    if [ $dependency ]; then
+    {% if dependency is defined and dependency %}
         new_job_id=$(sbatch --array=1-$remainder%$max_jobs --dependency=afterok:$job_id sbatch.sh $start_task | awk '{print $4}')
-    else
+    {% else %}
         new_job_id=$(sbatch --array=1-$remainder%$max_jobs sbatch.sh $start_task | awk '{print $4}')
-    fi
+    {% endif %}
     echo $new_job_id >> job_id.txt
 fi
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -4,7 +4,7 @@
 total_tasks={{njobs}}
 
 # Set the number of tasks per array job
-batch_size={{array_size}}
+batch_size={{array_batch_size}}
 
 # Set max running jobs
 max_jobs={{max_running_jobs}}
@@ -15,7 +15,7 @@ remainder=$((total_tasks % batch_size))
 echo "num_batches: $num_batches"
 echo "remainder: $remainder"
 
-# Submit the first array job with tasks 1-array_size
+# Submit the first array job with tasks 1-batch_size
 job_id=$(sbatch --array=1-$batch_size%$max_jobs sbatch.sh 0 | awk '{print $4}')
 echo $job_id >> job_id.txt
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/run_simulation.sh
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/run_simulation.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-JOB_DIRECTORY=$(find . -type d -maxdepth 1 -mindepth 1  | grep -v Assets | head -${SLURM_ARRAY_TASK_ID} | tail -1)
+SIMULATION_INDEX=$((${SLURM_ARRAY_TASK_ID} + $1))
+JOB_DIRECTORY=$(find . -type d -maxdepth 1 -mindepth 1  | grep -v Assets | head -$SIMULATION_INDEX | tail -1)
 cd $JOB_DIRECTORY
 bash _run.sh 1> stdout.txt 2> stderr.txt

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/sbatch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/sbatch.sh.jinja2
@@ -44,7 +44,6 @@
 {% if sbatch_custom is defined and sbatch_custom is not none %}
 #SBATCH {{sbatch_custom}}
 {% endif %}
-## SBATCH --array=1-{{njobs}}%{{max_running_jobs}}
 #SBATCH --open-mode=append
 #SBATCH --output=stdout.txt
 #SBATCH --error=stderr.txt
@@ -57,7 +56,6 @@ module load {{m}}
 {% endif %}
 
 # All submissions happen at the experiment level
-# echo $SLURM_ARRAY_JOB_ID >> job_id.txt
 srun run_simulation.sh
 wait
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/sbatch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/sbatch.sh.jinja2
@@ -44,7 +44,7 @@
 {% if sbatch_custom is defined and sbatch_custom is not none %}
 #SBATCH {{sbatch_custom}}
 {% endif %}
-#SBATCH --array=1-{{njobs}}%{{max_running_jobs}}
+## SBATCH --array=1-{{njobs}}%{{max_running_jobs}}
 #SBATCH --open-mode=append
 #SBATCH --output=stdout.txt
 #SBATCH --error=stderr.txt
@@ -57,6 +57,8 @@ module load {{m}}
 {% endif %}
 
 # All submissions happen at the experiment level
-echo $SLURM_ARRAY_JOB_ID > job_id.txt
+# echo $SLURM_ARRAY_JOB_ID >> job_id.txt
 srun run_simulation.sh
 wait
+
+

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/sbatch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/sbatch.sh.jinja2
@@ -56,7 +56,7 @@ module load {{m}}
 {% endif %}
 
 # All submissions happen at the experiment level
-srun run_simulation.sh
+srun run_simulation.sh $1
 wait
 
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/experiment_operations.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/experiment_operations.py
@@ -280,7 +280,7 @@ class SlurmPlatformExperimentOperations(IPlatformExperimentOperations):
                 return
             else:
                 result = self.platform._op_client.cancel_job(job_id)
-                user_logger.info(result)
+                user_logger.info(f"Cancel Experiment {experiment_id}: {result}")
                 return result
         else:
             user_logger.info(f"Experiment {experiment_id} is not running, no cancel needed...")

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/experiment_operations.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/experiment_operations.py
@@ -117,11 +117,12 @@ class SlurmPlatformExperimentOperations(IPlatformExperimentOperations):
         else:
             return self.platform._suites.get(experiment.parent_id, raw=True, **kwargs)
 
-    def platform_run_item(self, experiment: Experiment, **kwargs):
+    def platform_run_item(self, experiment: Experiment, dry_run: bool = False, **kwargs):
         """
         Run experiment.
         Args:
             experiment: idmtools Experiment
+            dry_run: True/False
             kwargs: keyword arguments used to expand functionality
         Returns:
             None
@@ -132,16 +133,12 @@ class SlurmPlatformExperimentOperations(IPlatformExperimentOperations):
         # Generate/update metadata
         self.platform._metas.dump(experiment)
         # Commission
-        dry_run = kwargs.get('dry_run', False)
         if not dry_run:
-            slurm_job_id = self.platform._op_client.submit_job(experiment, **kwargs)
-            working_directory = self.platform._op_client.get_directory(experiment)
-            self.platform._op_client.create_file(working_directory.joinpath('job_id.txt'), slurm_job_id)
-        else:
-            slurm_job_id = None
+            self.platform._op_client.submit_job(experiment, **kwargs)
+
         suite_id = experiment.parent_id or experiment.suite_id
 
-        user_logger.info(f'job_id: {slurm_job_id}')
+        # user_logger.info(f'job_id: {slurm_job_id}')
         user_logger.info(f'job_directory: {Path(self.platform.job_directory).resolve()}')
         user_logger.info(f'suite: {str(suite_id)}')
         user_logger.info(f'experiment: {experiment.id}')
@@ -279,7 +276,7 @@ class SlurmPlatformExperimentOperations(IPlatformExperimentOperations):
             logger.debug(f"cancel slurm job for experiment: {experiment_id}...")
             job_id = self.platform._op_client.get_job_id(experiment_id, ItemType.EXPERIMENT)
             if job_id is None:
-                logger.debug(f"Slurn job for experiment: {experiment_id} is not available!")
+                logger.debug(f"Slurm job for experiment: {experiment_id} is not available!")
                 return
             else:
                 result = self.platform._op_client.cancel_job(job_id)
@@ -299,5 +296,15 @@ class SlurmPlatformExperimentOperations(IPlatformExperimentOperations):
             None
         """
         super().post_run_item(experiment, **kwargs)
+
+        job_ids = self.platform._op_client.get_job_id(experiment.id, ItemType.EXPERIMENT)
+        if job_ids is None:
+            logger.debug(f"Slurn job for experiment: {experiment.id} is not available!")
+            user_logger.info("Slurm Job Ids: None")
+        else:
+            job_ids = [f'    {id}' for id in job_ids]
+            user_logger.info("Slurm Job Ids:")
+            user_logger.info('\n'.join(job_ids))
+
         user_logger.info(
             f'\nYou may try the following command to check simulations running status: \n  idmtools slurm {os.path.abspath(self.platform.job_directory)} status --exp-id {experiment.id}')

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/simulation_operations.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/simulation_operations.py
@@ -215,7 +215,7 @@ class SlurmPlatformSimulationOperations(IPlatformSimulationOperations):
                 return
             else:
                 result = self.platform._op_client.cancel_job(job_id)
-                user_logger.info(result)
+                user_logger.info(f"Cancel Simulation: {sim_id}: {result}")
                 return result
         else:
             user_logger.info(f"Simulation {sim_id} is not running, no cancel needed...")

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/simulation_operations.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/simulation_operations.py
@@ -211,7 +211,7 @@ class SlurmPlatformSimulationOperations(IPlatformSimulationOperations):
             logger.debug(f"cancel slurm job for simulation: {sim_id}...")
             job_id = self.platform._op_client.get_job_id(sim_id, ItemType.SIMULATION)
             if job_id is None:
-                logger.debug(f"Slurn job for simulation: {sim_id} is not available!")
+                logger.debug(f"Slurm job for simulation: {sim_id} is not available!")
                 return
             else:
                 result = self.platform._op_client.cancel_job(job_id)

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/utils.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/utils.py
@@ -105,7 +105,7 @@ def get_max_array_size():
         for line in output.decode().splitlines():
             if line.startswith("MaxArraySize"):
                 max_array_size = int(line.split("=")[1])
-                return max_array_size
+                return max_array_size - 1
     except (subprocess.CalledProcessError, IndexError, ValueError):
         pass
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/utils.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/utils.py
@@ -95,6 +95,11 @@ def add_dummy_suite(experiment: Experiment, suite_name: str = None, tags: Dict =
 
 
 def get_max_array_size():
+    """
+    Get Slurm MaxArraySize from configuration.
+    Returns:
+        Slurm system MaxArraySize
+    """
     try:
         output = subprocess.check_output(['scontrol', 'show', 'config'])
         for line in output.decode().splitlines():

--- a/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/utils.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/platform_operations/utils.py
@@ -3,6 +3,7 @@ This is SlurmPlatform operations utils.
 
 Copyright 2021, Bill & Melinda Gates Foundation. All rights reserved.
 """
+import subprocess
 from typing import Dict
 from idmtools.core import ItemType
 from idmtools.entities import Suite
@@ -91,3 +92,16 @@ def add_dummy_suite(experiment: Experiment, suite_name: str = None, tags: Dict =
     suite.add_experiment(experiment)
 
     return suite
+
+
+def get_max_array_size():
+    try:
+        output = subprocess.check_output(['scontrol', 'show', 'config'])
+        for line in output.decode().splitlines():
+            if line.startswith("MaxArraySize"):
+                max_array_size = int(line.split("=")[1])
+                return max_array_size
+    except (subprocess.CalledProcessError, IndexError, ValueError):
+        pass
+
+    return None

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_operations/local_operations.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_operations/local_operations.py
@@ -174,7 +174,7 @@ class LocalSlurmOperations(SlurmOperations):
             logger.debug(f"Failed to change file mode for executable: {exe}")
 
     def create_batch_file(self, item: Union[Experiment, Simulation], max_running_jobs: int = None, retries: int = None,
-                          array_size: int = None, dependency: bool = True, **kwargs) -> None:
+                          array_batch_size: int = None, dependency: bool = True, **kwargs) -> None:
         """
         Create batch file.
         Args:
@@ -184,7 +184,7 @@ class LocalSlurmOperations(SlurmOperations):
             None
         """
         if isinstance(item, Experiment):
-            generate_batch(self.platform, item, max_running_jobs, array_size, dependency)
+            generate_batch(self.platform, item, max_running_jobs, array_batch_size, dependency)
             generate_script(self.platform, item, max_running_jobs)
         elif isinstance(item, Simulation):
             generate_simulation_script(self.platform, item, retries)

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_operations/local_operations.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_operations/local_operations.py
@@ -16,7 +16,7 @@ from idmtools.core import ItemType, EntityStatus
 from idmtools.entities import Suite
 from idmtools.entities.experiment import Experiment
 from idmtools.entities.simulation import Simulation
-from idmtools_platform_slurm.assets import generate_script, generate_simulation_script
+from idmtools_platform_slurm.assets import generate_batch, generate_script, generate_simulation_script
 from idmtools_platform_slurm.slurm_operations.operations_interface import SlurmOperations
 from idmtools_platform_slurm.slurm_operations.slurm_constants import SLURM_MAPS
 
@@ -94,9 +94,11 @@ class LocalSlurmOperations(SlurmOperations):
         else:
             raise RuntimeError('Only support Suite/Experiment/Simulation or not None dest.')
 
-        exist_ok = exist_ok if exist_ok is not None else IdmConfigParser.get_option(option="EXIST_ITEM_DIR", fallback=self.platform.dir_exist_ok)
+        exist_ok = exist_ok if exist_ok is not None else IdmConfigParser.get_option(option="EXIST_ITEM_DIR",
+                                                                                    fallback=self.platform.dir_exist_ok)
         if not exist_ok and os.path.exists(target):
-            raise RuntimeError(f'Item directory {target} already exists. Exist_ok flag set to false to avoid data being overwritten.')
+            raise RuntimeError(
+                f'Item directory {target} already exists. Exist_ok flag set to false to avoid data being overwritten.')
         else:
             target.mkdir(parents=True, exist_ok=exist_ok)
 
@@ -171,7 +173,8 @@ class LocalSlurmOperations(SlurmOperations):
         except:
             logger.debug(f"Failed to change file mode for executable: {exe}")
 
-    def create_batch_file(self, item: Union[Experiment, Simulation], **kwargs) -> None:
+    def create_batch_file(self, item: Union[Experiment, Simulation], max_running_jobs: int = None, retries: int = None,
+                          array_size: int = None, dependency: bool = True, **kwargs) -> None:
         """
         Create batch file.
         Args:
@@ -181,10 +184,9 @@ class LocalSlurmOperations(SlurmOperations):
             None
         """
         if isinstance(item, Experiment):
-            max_running_jobs = kwargs.get('max_running_jobs', None)
+            generate_batch(self.platform, item, max_running_jobs, array_size, dependency)
             generate_script(self.platform, item, max_running_jobs)
         elif isinstance(item, Simulation):
-            retries = kwargs.get('retries', None)
             generate_simulation_script(self.platform, item, retries)
         else:
             raise NotImplementedError(f"{item.__class__.__name__} is not supported for batch creation.")
@@ -200,10 +202,7 @@ class LocalSlurmOperations(SlurmOperations):
         """
         if isinstance(item, Experiment):
             working_directory = self.get_directory(item)
-            result = subprocess.run(['sbatch', '--parsable', 'sbatch.sh'], stdout=subprocess.PIPE,
-                                    cwd=str(working_directory))
-            slurm_job_id = result.stdout.decode('utf-8').strip().split(';')[0]
-            return slurm_job_id
+            subprocess.run(['bash', 'batch.sh'], stdout=subprocess.PIPE, cwd=str(working_directory))
         elif isinstance(item, Simulation):
             pass
         else:
@@ -264,14 +263,14 @@ class LocalSlurmOperations(SlurmOperations):
         stdout = "Success" if result.returncode == 0 else 'Error'
         return stdout
 
-    def get_job_id(self, item_id: str, item_type: ItemType) -> str:
+    def get_job_id(self, item_id: str, item_type: ItemType) -> List:
         """
         Retrieve the job id for item that had been run.
         Args:
             item_id: id of experiment/simulation
             item_type: ItemType (Experiment or Simulation)
         Returns:
-            str
+            List of slurm job ids
         """
         if item_type not in (ItemType.EXPERIMENT, ItemType.SIMULATION):
             raise RuntimeError(f"Not support item type: {item_type}")
@@ -283,6 +282,5 @@ class LocalSlurmOperations(SlurmOperations):
             return None
 
         job_id = open(job_id_file).read().strip()
-        return job_id
-
+        return job_id.split('\n')
     # endregion

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -31,7 +31,7 @@ logger = getLogger(__name__)
 op_defaults = dict(default=None, compare=False, metadata={"pickle_ignore": True})
 CONFIG_PARAMETERS = ['ntasks', 'partition', 'nodes', 'mail_type', 'mail_user', 'ntasks_per_core', 'cpus_per_task',
                      'mem_per_cpu', 'time', 'constraint', 'account', 'mem', 'exclusive', 'requeue', 'sbatch_custom',
-                     'max_running_jobs', 'max_array_size']
+                     'max_running_jobs', 'array_batch_size']
 
 
 @dataclass(repr=False)
@@ -106,7 +106,7 @@ class SlurmPlatform(IPlatform):
     dir_exist_ok: bool = field(default=False, repr=False, compare=False)
 
     # Set array max size for Slurm job
-    max_array_size: int = field(default=1000, metadata=dict(sbatch=False))
+    array_batch_size: int = field(default=None, metadata=dict(sbatch=False))
 
     # determine if run script as Slurm job
     run_on_slurm: bool = field(default=False, repr=False, compare=False)
@@ -131,11 +131,9 @@ class SlurmPlatform(IPlatform):
             raise ValueError("Job Directory is required.")
 
         # check max_array_size from slurm configuration
+        self._max_array_size = None
         if slurm_installed():
-            _max_array_size = get_max_array_size()
-            if _max_array_size is not None:
-                if self.max_array_size > _max_array_size:
-                    self.max_array_size = _max_array_size
+            self._max_array_size = get_max_array_size()
 
         super().__post_init__()
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -22,15 +22,16 @@ from idmtools_platform_slurm.platform_operations.simulation_operations import Sl
 from idmtools_platform_slurm.slurm_operations.operations_interface import SlurmOperations
 from idmtools_platform_slurm.slurm_operations.slurm_constants import SlurmOperationalMode
 from idmtools_platform_slurm.platform_operations.suite_operations import SlurmPlatformSuiteOperations
-from idmtools_platform_slurm.platform_operations.utils import SlurmSuite, SlurmExperiment, SlurmSimulation
-from idmtools_platform_slurm.utils.slurm_job import run_script_on_slurm
+from idmtools_platform_slurm.platform_operations.utils import SlurmSuite, SlurmExperiment, SlurmSimulation, \
+    get_max_array_size
+from idmtools_platform_slurm.utils.slurm_job import run_script_on_slurm, slurm_installed
 
 logger = getLogger(__name__)
 
 op_defaults = dict(default=None, compare=False, metadata={"pickle_ignore": True})
 CONFIG_PARAMETERS = ['ntasks', 'partition', 'nodes', 'mail_type', 'mail_user', 'ntasks_per_core', 'cpus_per_task',
                      'mem_per_cpu', 'time', 'constraint', 'account', 'mem', 'exclusive', 'requeue', 'sbatch_custom',
-                     'max_running_jobs']
+                     'max_running_jobs', 'max_array_size']
 
 
 @dataclass(repr=False)
@@ -104,6 +105,9 @@ class SlurmPlatform(IPlatform):
     # Specifies default setting of whether slurm should fail if item directory already exists
     dir_exist_ok: bool = field(default=False, repr=False, compare=False)
 
+    # Set array max size for Slurm job
+    max_array_size: int = field(default=1000, metadata=dict(sbatch=False))
+
     # determine if run script as Slurm job
     run_on_slurm: bool = field(default=False, repr=False, compare=False)
 
@@ -125,16 +129,23 @@ class SlurmPlatform(IPlatform):
         self.supported_types = {ItemType.SUITE, ItemType.EXPERIMENT, ItemType.SIMULATION}
         if self.job_directory is None:
             raise ValueError("Job Directory is required.")
+
+        # check max_array_size from slurm configuration
+        if slurm_installed():
+            _max_array_size = get_max_array_size()
+            if _max_array_size is not None:
+                if self.max_array_size > _max_array_size:
+                    self.max_array_size = _max_array_size
+
         super().__post_init__()
 
         # check if run script as a slurm job
         r = run_script_on_slurm(self, run_on_slurm=self.run_on_slurm)
         if r:
-            exit(0)     # finish the current workflow
+            exit(0)  # finish the current workflow
 
     def __init_interfaces(self):
         if self.mode == SlurmOperationalMode.SSH:
-            # from idmtools_platform_slurm.slurm_operations.remote_operations import RemoteSlurmOperations
             raise NotImplementedError("SSH mode has not been implemented on the Slurm Platform")
         elif self.mode == SlurmOperationalMode.BRIDGED:
             from idmtools_platform_slurm.slurm_operations.bridged_operations import BridgedLocalSlurmOperations

--- a/idmtools_platform_slurm/idmtools_platform_slurm/utils/slurm_job/slurm_job.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/utils/slurm_job/slurm_job.py
@@ -109,7 +109,7 @@ class SlurmJob:
 
         if not dry_run:
             if not slurm_installed():
-                user_logger.warn('Slurm is not installed/available!')
+                user_logger.warnning('Slurm is not installed/available!')
                 exit(-1)
 
             user_logger.info('Script is running as a slurm job!\n')
@@ -122,7 +122,7 @@ class SlurmJob:
 
             user_logger.info(f"{'job_id: '.ljust(20)} {self.slurm_job_id}")
             user_logger.info(f"{'job_directory: '.ljust(20)} {self.platform.job_directory}\n")
-            user_logger.warn(MSG)
+            user_logger.warnning(MSG)
         else:
             print('Script run with dry_run = True')
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/utils/slurm_job/slurm_job.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/utils/slurm_job/slurm_job.py
@@ -7,14 +7,11 @@ import os
 import subprocess
 from os import PathLike
 from pathlib import Path
-from dataclasses import dataclass, field, InitVar, fields
-from typing import NoReturn, Optional, Union, Dict, List, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import NoReturn, Union, List, TYPE_CHECKING
 from idmtools.core import NoPlatformException
-from idmtools.core.platform_factory import Platform
-from idmtools.entities.command_task import CommandTask
-from idmtools.entities.simulation import Simulation
 from jinja2 import Template
-from logging import getLogger, DEBUG
+from logging import getLogger
 from idmtools_platform_slurm.utils.slurm_job import create_slurm_indicator, slurm_installed
 
 user_logger = getLogger('user')

--- a/idmtools_platform_slurm/idmtools_platform_slurm/utils/slurm_job/slurm_job.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/utils/slurm_job/slurm_job.py
@@ -106,7 +106,7 @@ class SlurmJob:
 
         if not dry_run:
             if not slurm_installed():
-                user_logger.warnning('Slurm is not installed/available!')
+                user_logger.warning('Slurm is not installed/available!')
                 exit(-1)
 
             user_logger.info('Script is running as a slurm job!\n')
@@ -119,7 +119,7 @@ class SlurmJob:
 
             user_logger.info(f"{'job_id: '.ljust(20)} {self.slurm_job_id}")
             user_logger.info(f"{'job_directory: '.ljust(20)} {self.platform.job_directory}\n")
-            user_logger.warnning(MSG)
+            user_logger.warning(MSG)
         else:
             print('Script run with dry_run = True')
 

--- a/idmtools_platform_slurm/tests/test_suite_experiment.py
+++ b/idmtools_platform_slurm/tests/test_suite_experiment.py
@@ -62,11 +62,12 @@ class TestSuiteExperiment(ITestWithPersistence):
             experiment_dir = self.platform.get_directory(experiment)
             experiment_sub_dirs, experiment_files = self.get_dirs_and_files(experiment_dir)
             # Verify all files under experiment
-            self.assertTrue(len(experiment_files) == 3)
+            self.assertTrue(len(experiment_files) == 4)
             experiment_path_prefix = self.job_directory + "/" + suite.id + "/" + experiment.id + "/"
             expected_files = set([pathlib.Path(experiment_path_prefix + "metadata.json"),
                                   pathlib.Path(experiment_path_prefix + "run_simulation.sh"),
-                                  pathlib.Path(experiment_path_prefix + "sbatch.sh")])
+                                  pathlib.Path(experiment_path_prefix + "sbatch.sh"),
+                                  pathlib.Path(experiment_path_prefix + "batch.sh")])
             self.assertSetEqual(set(experiment_files), expected_files)
             # Verify all sub directories under experiment
             self.assertTrue(len(experiment_sub_dirs) == 2)


### PR DESCRIPTION
This PR aims to address
Ticket: Potential issue with max count of simulations in slurm platform #1998 

This PR contains the following implementation:

- Scripts/code refactored to generate multiple Slurm jobs
•	Generate single batch file which will break "BIG" arrary into some "SMALL" arrays
- Retrieve MaxArraySize from Slurm configuration and take it into account when building Slurm job array
- Provide user option to set array size they like
- Store multiple Slurm job ids and display to user/screen
- Multiple Slurm jobs: dependency? Provide user with option

Note: the following are not implemented yet

- Apply this consideration to cancel experiment case and verify working as before
- Verify idmtools-calibra still works (which uses cancel functionality)
- Consider the Bridged mode case in SlurmPlatform

All these rest will be put into a new PR or just added to current PR.