### PR TITLE
Singularity compatibility update

### DIFF
--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/_run.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/_run.sh.jinja2
@@ -23,7 +23,7 @@ do
         {% if simulation.task.command.cmd.startswith('singularity') %}
             {{simulation.task.command.cmd}}
         {% else %}
-            singularity exec {{simulation.task.sif_path}} {{simulation.task.command.cmd}}
+            singularity exec -B $(pwd) -B $(pwd)/../Assets --pwd $(pwd) {{simulation.task.sif_path}} {{simulation.task.command.cmd}}
         {% endif %}
     {% else %}
         {{simulation.task.command.cmd}}


### PR DESCRIPTION
This update to how we use 'singularity exec' works at NYU for singularity versions 3.1, 3.7, 3.9 . I suspect it will work for 3.8 and 3.10 (our dev cluster and NU), but this would need to be verified.