### PR TITLE
Revert "Update pytest requirement from ~=7.2.0 to ~=8.0.0"

### DIFF
--- a/idmtools_core/dev_requirements.txt
+++ b/idmtools_core/dev_requirements.txt
@@ -9,7 +9,7 @@ pytest-mock
 pytest-runner~=6.0
 pytest-timeout~=2.1.0
 pytest-xdist~=3.3
-pytest~=8.0.0
+pytest~=7.2.0
 xmlrunner~=1.7.7
 pytest-lazy-fixture
 jinja2~=3.1.3


### PR DESCRIPTION
Reverts InstituteforDiseaseModeling/idmtools#2179

https://github.com/TvoroG/pytest-lazy-fixture/issues/65