### PR TITLE
unregister plugin in test_hooks.py to avoid affecting other test in p…

### DIFF
--- a/idmtools_platform_comps/tests/test_hooks.py
+++ b/idmtools_platform_comps/tests/test_hooks.py
@@ -29,17 +29,30 @@ from idmtools.registry.functions import FunctionPluginManager
 from idmtools.registry.hook_specs import function_hook_impl
 
 
-def initialize_plugins(**kwargs):
+def initialize_plugins(name="Plugin_create_hook", **kwargs):
     """
     Setup plugins.
     Args:
+        name: Plugin name
         kwargs: user inputs
     Returns:
         None
     """
     # register plugins
     fpm = FunctionPluginManager.instance()
-    fpm.register(Plugin_create_hook(**kwargs))
+    fpm.register(Plugin_create_hook(**kwargs), name=name)
+
+
+def un_register_plugins(name="Plugin_create_hook"):
+    """
+    Unregister plugins.
+    Args:
+        name: Plugin name
+    Returns:
+        None
+    """
+    fpm = FunctionPluginManager.instance()
+    fpm.unregister(Plugin_create_hook(), name=name)
 
 
 class Plugin_create_hook:
@@ -265,7 +278,7 @@ class TestHooks(ITestWithPersistence):
         sim_tags = COMPSSimulation.get(exp.simulations[0].id, QueryCriteria().select_children('tags')).tags
         sim_tags.pop('task_type')
         self.assertDictEqual(sim_tags, {})
-
+        un_register_plugins()
 
 
 

--- a/idmtools_platform_comps/tests/test_hooks.py
+++ b/idmtools_platform_comps/tests/test_hooks.py
@@ -29,9 +29,9 @@ from idmtools.registry.functions import FunctionPluginManager
 from idmtools.registry.hook_specs import function_hook_impl
 
 
-def initialize_plugins(name="Plugin_create_hook", **kwargs):
+def register_plugins(name="Plugin_create_hook", **kwargs):
     """
-    Setup plugins.
+    Register plugins.
     Args:
         name: Plugin name
         kwargs: user inputs
@@ -257,10 +257,7 @@ class TestHooks(ITestWithPersistence):
         exp.simulations = [sim]
         kwargs = {"my_test": 1}
 
-        def _pre_run(**kwargs):
-            initialize_plugins(**kwargs)
-
-        _pre_run(**kwargs)
+        register_plugins(**kwargs)
         exp.run(True)
         # verify idmtools experiment tags
         expected_tags = {'tag_key': 'tag_value'}
@@ -279,6 +276,4 @@ class TestHooks(ITestWithPersistence):
         sim_tags.pop('task_type')
         self.assertDictEqual(sim_tags, {})
         un_register_plugins()
-
-
 


### PR DESCRIPTION
unregister plugin in test_hooks.py to avoid affecting other test in parallel run
Fixed #2233 