### PR TITLE
Platform factory refactor

### DIFF
--- a/dev_scripts/create_auth_token_args.py
+++ b/dev_scripts/create_auth_token_args.py
@@ -58,6 +58,6 @@ if __name__ == '__main__':
         sys.exit(-1)
 
     compshost = args.comps_url
-
+    Client.logout(compshost)
     Client.login(compshost, StaticCredentialPrompt(comps_url=args.comps_url, username=args.username,
                                                    password=args.password))

--- a/idmtools_core/idmtools/analysis/platform_anaylsis.py
+++ b/idmtools_core/idmtools/analysis/platform_anaylsis.py
@@ -257,7 +257,6 @@ class PlatformAnalysis:
         """
         # Pickle the platform args
         platform_kwargs = self.platform._kwargs
-        platform_kwargs["missing_ok"] = self.platform._missing_ok
         self.additional_files.add_or_replace_asset(
             Asset(filename="platform_args.pkl", content=pickle.dumps(platform_kwargs)))
 

--- a/idmtools_core/idmtools/config/idm_config_parser.py
+++ b/idmtools_core/idmtools/config/idm_config_parser.py
@@ -11,7 +11,7 @@ import json
 import os
 from configparser import ConfigParser
 from logging import getLogger, DEBUG
-from typing import Any, Dict, List
+from typing import Any, Dict
 from idmtools.core import TRUTHY_VALUES
 from idmtools.utils.info import get_help_version_url
 
@@ -467,4 +467,3 @@ class IdmConfigParser:
         cls._instance = None
         cls._config_path = None
         cls._block = None
-

--- a/idmtools_core/idmtools/config/idm_config_parser.py
+++ b/idmtools_core/idmtools/config/idm_config_parser.py
@@ -95,7 +95,7 @@ class IdmConfigParser:
             ft = field_type[fn]
             if ft in (int, float, str):
                 inputs[fn] = ft(section[fn])
-            elif ft is bool:
+            elif ft is bool and not isinstance(section[fn], bool):
                 inputs[fn] = ast.literal_eval(section[fn])
         return inputs
 
@@ -232,7 +232,7 @@ class IdmConfigParser:
         from idmtools.core.logging import setup_logging, IdmToolsLoggingConfig
         # set up default log values
         log_config = dict()
-        # try to fetch options from config file and from environment vars
+        # try to fetch logging options from config file and from environment vars
         for field in fields(IdmToolsLoggingConfig):
             value = cls.get_option("logging", field.name, fallback=None)
             if value is not None:
@@ -426,7 +426,7 @@ class IdmConfigParser:
         Returns:
             True if the section exists, False otherwise
         """
-        return cls._config.has_section(section.lower())
+        return cls._config.has_section(section.lower()) if cls._config else False
 
     @classmethod
     @initialization
@@ -468,16 +468,3 @@ class IdmConfigParser:
         cls._config_path = None
         cls._block = None
 
-    @classmethod
-    @initialization()
-    def ini_file_sections(cls) -> List[str]:
-        """
-        Get the sections in the INI file.
-        Returns:
-            A list of the section name in the INI file.
-        """
-        # Get the section names
-        if cls._config is None:
-            return []
-        sections = cls._config.sections()
-        return list(map(str.upper, sections))

--- a/idmtools_core/idmtools/config/idm_config_parser.py
+++ b/idmtools_core/idmtools/config/idm_config_parser.py
@@ -93,10 +93,18 @@ class IdmConfigParser:
         fs = set(field_type.keys()).intersection(set(section.keys()))
         for fn in fs:
             ft = field_type[fn]
-            if ft in (int, float, str):
-                inputs[fn] = ft(section[fn])
-            elif ft is bool and not isinstance(section[fn], bool):
-                inputs[fn] = ast.literal_eval(section[fn])
+            try:
+                if ft in (int, float, str):
+                    inputs[fn] = ft(section[fn])
+                elif ft is bool:
+                    if isinstance(section[fn], str):
+                        inputs[fn] = ast.literal_eval(section[fn])
+                    else:
+                        inputs[fn] = section[fn]
+            except ValueError as e:
+                user_logger.error(
+                    f"The field {fn} requires a value of type {ft.__name__}. You provided <{section[fn]}>")
+                raise e
         return inputs
 
     @classmethod

--- a/idmtools_core/idmtools/config/idm_config_parser.py
+++ b/idmtools_core/idmtools/config/idm_config_parser.py
@@ -199,12 +199,9 @@ class IdmConfigParser:
 
         # If we didn't find a file, warn the user and init logging
         if ini_file is None:
-            if os.getenv("IDMTOOLS_NO_CONFIG_WARNING", "F").lower() not in TRUTHY_VALUES:
-                # We use print since logger isn't configured unless there is an override(cli)
-                print(f"/!\\ WARNING: File '{file_name}' Not Found! For details on how to configure idmtools, see {get_help_version_url('configuration.html')} for details on how to configure idmtools.")
             if os.getenv("NO_LOGGING_INIT", "f").lower() not in TRUTHY_VALUES:
                 cls._init_logging()
-
+            logger.warning(f"/!\\ WARNING: File '{file_name}' Not Found! For details on how to configure idmtools, see {get_help_version_url('configuration.html')} for details on how to configure idmtools.")
             return
 
         # Load file
@@ -273,6 +270,8 @@ class IdmConfigParser:
             ValueError: If the block doesn't exist
         """
         original_case_section = section
+        if section is None:
+            return None
         lower_case_section = section.lower()
         if (not cls.found_ini() or not cls.has_section(section=lower_case_section)) and error:
             raise ValueError(f"Block '{original_case_section}' doesn't exist!")

--- a/idmtools_core/idmtools/config/idm_config_parser.py
+++ b/idmtools_core/idmtools/config/idm_config_parser.py
@@ -11,7 +11,7 @@ import json
 import os
 from configparser import ConfigParser
 from logging import getLogger, DEBUG
-from typing import Any, Dict
+from typing import Any, Dict, List
 from idmtools.core import TRUTHY_VALUES
 from idmtools.utils.info import get_help_version_url
 
@@ -311,7 +311,7 @@ class IdmConfigParser:
             return fallback
 
         if section:
-            return cls._config.get(section, option, fallback=fallback)
+            return cls._config.get(section.lower(), option, fallback=fallback)
         else:
             return cls._config.get("COMMON", option, fallback=fallback)
 
@@ -467,3 +467,17 @@ class IdmConfigParser:
         cls._instance = None
         cls._config_path = None
         cls._block = None
+
+    @classmethod
+    @initialization()
+    def ini_file_sections(cls) -> List[str]:
+        """
+        Get the sections in the INI file.
+        Returns:
+            A list of the section name in the INI file.
+        """
+        # Get the section names
+        if cls._config is None:
+            return []
+        sections = cls._config.sections()
+        return list(map(str.upper, sections))

--- a/idmtools_core/idmtools/core/platform_factory.py
+++ b/idmtools_core/idmtools/core/platform_factory.py
@@ -223,15 +223,15 @@ class Platform:
         Returns:
             The type of the platform, section, and whether it is an alias.
         """
-        # if block is a section in the idmtools.ini file
-        if block and IdmConfigParser.has_section(block):
-            platform_type, section, is_alias = cls._get_type_from_ini(block)
-
-        # else if block is an alias
-        elif block and block.upper() in cls._aliases:
+        # If block is an alias
+        if block and block.upper() in cls._aliases:
             platform_type, section, is_alias = cls._get_type_from_platform_aliases(block)
 
-        # all other cases
+        # Else if block is a section in the idmtools.ini file
+        elif block and IdmConfigParser.has_section(block):
+            platform_type, section, is_alias = cls._get_type_from_ini(block)
+
+        # Else, all other cases
         else:
             platform_type, section, is_alias = cls._get_type_from_platform_kwargs(block, **kwargs)
 
@@ -305,7 +305,7 @@ class Platform:
         """
         try:
             from idmtools.core.logging import VERBOSE
-            # is output enabled and is showing of platform config enabled?
+            # Is output enabled and is showing of platform config enabled?
             if IdmConfigParser.is_output_enabled() and IdmConfigParser.get_option(None, "SHOW_PLATFORM_CONFIG", 't').lower() in TRUTHY_VALUES:
                 if block is not None:
                     if is_alias or inputs != section:  # second condition is to show updated values from kwargs for the block

--- a/idmtools_core/idmtools/core/platform_factory.py
+++ b/idmtools_core/idmtools/core/platform_factory.py
@@ -116,7 +116,6 @@ class Platform:
         Raises:
             ValueError or Exception: If the platform is of an unknown type.
         """
-        global current_platform, current_platform_stack
         from idmtools.registry.platform_specification import PlatformPlugins
 
         # Load all Platform plugins
@@ -204,8 +203,8 @@ class Platform:
         for f in field_not_used:
             inputs.pop(f)
 
-        # Display block info
-        cls._display_inputs(platform_type, inputs)
+        # Display input info
+        cls._display_inputs(platform_cls, inputs)
 
         # Now create Platform using the data with the correct data types
         return platform_cls(**inputs)
@@ -290,17 +289,17 @@ class Platform:
         return platform_type, section, is_alias
 
     @classmethod
-    def _display_inputs(cls, platform_type: str, inputs: dict):
+    def _display_inputs(cls, platform_cls: object, inputs: dict):
         """
         Display inputs required for platform creation  on the console.
 
         Args:
-            platform_type: The platform type.
+            platform_cls: The platform object.
             inputs: The inputs.
         """
         from idmtools.core.logging import VERBOSE
 
         if IdmConfigParser.is_output_enabled() and IdmConfigParser.get_option(None, "SHOW_PLATFORM_CONFIG",
                                                                               't').lower() in TRUTHY_VALUES:
-            user_logger.log(VERBOSE, f"\nInitializing {platform_type}Platform with:")
+            user_logger.log(VERBOSE, f"\nInitializing {platform_cls.__name__} with:")
             user_logger.log(VERBOSE, json.dumps(inputs, indent=3))

--- a/idmtools_core/idmtools/core/platform_factory.py
+++ b/idmtools_core/idmtools/core/platform_factory.py
@@ -15,7 +15,6 @@ from idmtools.core import TRUTHY_VALUES
 from idmtools.core.context import set_current_platform, remove_current_platform
 from idmtools.utils.entities import validate_user_inputs_against_dataclass
 
-
 if TYPE_CHECKING:  # pragma: no cover
     from idmtools.entities.iplatform import IPlatform
 
@@ -117,6 +116,8 @@ class Platform:
             ValueError or Exception: If the platform is of an unknown type.
         """
         from idmtools.registry.platform_specification import PlatformPlugins
+
+        IdmConfigParser.ensure_init()
 
         # Load all Platform plugins
         cls._platform_plugins = PlatformPlugins().get_plugin_map()

--- a/idmtools_core/idmtools/entities/iplatform.py
+++ b/idmtools_core/idmtools/entities/iplatform.py
@@ -7,7 +7,6 @@ Copyright 2021, Bill & Melinda Gates Foundation. All rights reserved.
 """
 import os
 import copy
-import warnings
 from abc import ABCMeta
 from dataclasses import dataclass
 from dataclasses import fields, field
@@ -47,7 +46,7 @@ from idmtools.utils.entities import validate_user_inputs_against_dataclass
 logger = getLogger(__name__)
 user_logger = getLogger('user')
 
-CALLER_LIST = ['_create_from_block',  # create platform through Platform Factory
+CALLER_LIST = ['_create_platform_from_block',  # create platform through Platform Factory
                'fetch',  # create platform through un-pickle
                'get',  # create platform through platform spec' get method
                '__newobj__',  # create platform through copy.deepcopy
@@ -121,8 +120,7 @@ class IPlatform(IItem, CacheEnabled, metaclass=ABCMeta):
 
         # Action based on the caller
         if caller not in CALLER_LIST:
-            warnings.warn(
-                "Please use Factory to create Platform! For example: \n    platform = Platform('COMPS', **kwargs)")
+            logger.warning("Please use Factory to create Platform! For example: \n    platform = Platform('COMPS', **kwargs)")
         return super().__new__(cls)
 
     def __post_init__(self) -> NoReturn:

--- a/idmtools_core/tests/idmtools.ini
+++ b/idmtools_core/tests/idmtools.ini
@@ -81,3 +81,7 @@ type = Bad
 
 
 [NOTYPE]
+
+[My_container]
+type        = Container
+job_directory = MY_JOB_DIRECTORY

--- a/idmtools_core/tests/idmtools.ini
+++ b/idmtools_core/tests/idmtools.ini
@@ -82,6 +82,6 @@ type = Bad
 
 [NOTYPE]
 
-[My_container]
-type        = Container
+[File_Platform]
+type        = File
 job_directory = MY_JOB_DIRECTORY

--- a/idmtools_core/tests/test_configuration.py
+++ b/idmtools_core/tests/test_configuration.py
@@ -95,13 +95,14 @@ class TestConfig(ITestWithPersistence):
 
     @skip_if_global_configuration_is_enabled
     @run_in_temp_dir
-    def test_no_idmtools_common(self):
+    @unittest.mock.patch("idmtools.config.idm_config_parser.logger")
+    def test_no_idmtools_common(self, mock_logger):
         with captured_output() as (out, err):
             IdmConfigParser(file_name="idmtools.ini")
             IdmConfigParser.ensure_init()
             max_workers = IdmConfigParser.get_option("COMMON", 'max_workers')
             self.assertIsNone(max_workers)
-            self.assertIn("WARNING: File 'idmtools.ini' Not Found!", out.getvalue())
+            mock_logger.warning.call_args_list[0].assert_called_with("File 'idmtools.ini' Not Found!")
 
     # enable config only through special file
     @pytest.mark.skipif(not all([os.environ.get("TEST_GLOBAL_CONFIG", 'n').lower() in TRUTHY_VALUES, os.environ.get('IDMTOOLS_CONFIG_FILE', None) is None, not os.path.exists(IdmConfigParser.get_global_configuration_name())]), reason="Either the environment variable TEST_GLOBAL_CONFIG is not set to true, you already have a global configuration, or IDMTOOLS_CONFIG_FILE is set")

--- a/idmtools_core/tests/test_copy.py
+++ b/idmtools_core/tests/test_copy.py
@@ -49,7 +49,7 @@ class TestCopy(ITestWithPersistence):
         super().tearDown()
 
     def test_deepcopy_assets(self):
-        test_platform = Platform("TestExecute", type='TestExecute')
+        test_platform = Platform("Test")
         task = CommandTask(command="python --version")
         e = Experiment.from_task(task=task, name="Example of experiment from task")
         e.add_asset(os.path.join(COMMON_INPUT_PATH, 'python_experiments', "model.py"))
@@ -72,7 +72,7 @@ class TestCopy(ITestWithPersistence):
         self.assertEqual(sim.assets, sim.assets)
 
     def test_deepcopy_experiment(self):
-        test_platform = Platform("TestExecute", type='TestExecute')
+        test_platform = Platform("Test")
         task = TestTask()
         ts = TemplatedSimulations(base_task=task)
         e = Experiment.from_template(ts)
@@ -104,7 +104,7 @@ class TestCopy(ITestWithPersistence):
         self.assertIn('Set self.maxDiff to None to see it', context.exception.args[0])
 
     def test_deepcopy_simulation(self):
-        test_platform = Platform("TestExecute", type='TestExecute')
+        test_platform = Platform("Test")
         task = TestTask()
         sim = Simulation.from_task(task=task)
 

--- a/idmtools_core/tests/test_copy.py
+++ b/idmtools_core/tests/test_copy.py
@@ -49,7 +49,7 @@ class TestCopy(ITestWithPersistence):
         super().tearDown()
 
     def test_deepcopy_assets(self):
-        test_platform = Platform("TestExecute", missing_ok=True)
+        test_platform = Platform("TestExecute", type='TestExecute')
         task = CommandTask(command="python --version")
         e = Experiment.from_task(task=task, name="Example of experiment from task")
         e.add_asset(os.path.join(COMMON_INPUT_PATH, 'python_experiments', "model.py"))
@@ -72,7 +72,7 @@ class TestCopy(ITestWithPersistence):
         self.assertEqual(sim.assets, sim.assets)
 
     def test_deepcopy_experiment(self):
-        test_platform = Platform("TestExecute", missing_ok=True)
+        test_platform = Platform("TestExecute", type='TestExecute')
         task = TestTask()
         ts = TemplatedSimulations(base_task=task)
         e = Experiment.from_template(ts)
@@ -104,7 +104,7 @@ class TestCopy(ITestWithPersistence):
         self.assertIn('Set self.maxDiff to None to see it', context.exception.args[0])
 
     def test_deepcopy_simulation(self):
-        test_platform = Platform("TestExecute", missing_ok=True)
+        test_platform = Platform("TestExecute", type='TestExecute')
         task = TestTask()
         sim = Simulation.from_task(task=task)
 

--- a/idmtools_core/tests/test_entity.py
+++ b/idmtools_core/tests/test_entity.py
@@ -221,7 +221,7 @@ class TestEntity(ITestWithPersistence):
         s.post_creation(fake_platform)
 
     def test_experiment_pre_creation_hooks(self):
-        fake_platform = Platform("TestExecute", missing_ok=True)
+        fake_platform = Platform("TestExecute", type="TestExecute")
         base_task = TestTask()
         sim = Simulation.from_task(base_task)
         builder = SimulationBuilder()
@@ -234,7 +234,7 @@ class TestEntity(ITestWithPersistence):
             self.assertEqual(mock_hook.call_count, 1)
 
     def test_experiment_post_creation_hooks(self):
-        fake_platform = Platform("TestExecute", missing_ok=True)
+        fake_platform = Platform("TestExecute", type="TestExecute")
         base_task = TestTask()
         sim = Simulation.from_task(base_task)
         builder = SimulationBuilder()

--- a/idmtools_core/tests/test_item_sequence.py
+++ b/idmtools_core/tests/test_item_sequence.py
@@ -84,7 +84,7 @@ class TestItemSequence(unittest.TestCase):
         self.assertTrue(sequence_file.exists())
         e = Experiment(name='Test Sequential IDs')
         self.assertTrue(e.id, "Experiment000000")
-        platform = Platform('Test', type='Test')
+        platform = Platform('TestExecute', type='TestExecute')
 
         e2 = Experiment(name='Test2')
         self.assertEqual(e2.id, "Experiment000001")

--- a/idmtools_core/tests/test_item_sequence.py
+++ b/idmtools_core/tests/test_item_sequence.py
@@ -84,7 +84,7 @@ class TestItemSequence(unittest.TestCase):
         self.assertTrue(sequence_file.exists())
         e = Experiment(name='Test Sequential IDs')
         self.assertTrue(e.id, "Experiment000000")
-        platform = Platform('Test', missing_ok=True)
+        platform = Platform('Test', type='Test')
 
         e2 = Experiment(name='Test2')
         self.assertEqual(e2.id, "Experiment000001")
@@ -157,7 +157,7 @@ class TestItemSequence(unittest.TestCase):
         self.assertTrue(run_time_a <= run_time_b or (run_time_a - run_time_b) > (run_time_b * .10))
 
     def _run_experiment(self, ):
-        platform = Platform('TestExecute', missing_ok=True)
+        platform = Platform('TestExecute', type='TestExecute')
 
         task = task = TestTask()
         ts = TemplatedSimulations(base_task=task)
@@ -183,7 +183,7 @@ class TestItemSequence(unittest.TestCase):
         sequence_file = self.get_sequence_file()
         mp = Path(COMMON_INPUT_PATH).joinpath("python").joinpath("model3.py")
         task = TestTask()
-        platform = Platform('TestExecute', missing_ok=True)
+        platform = Platform('TestExecute', type='TestExecute')
         ts = TemplatedSimulations(base_task=task)
         e = Experiment.from_template(ts)
         from idmtools.builders import SimulationBuilder
@@ -213,7 +213,7 @@ class TestItemSequence(unittest.TestCase):
         sequence_file = self.get_sequence_file()
         mp = Path(COMMON_INPUT_PATH).joinpath("python").joinpath("model3.py")
         task = TestTask()
-        platform = Platform('TestExecute', missing_ok=True)
+        platform = Platform('TestExecute', type='TestExecute')
         ts = TemplatedSimulations(base_task=task)
         e = Experiment.from_template(ts)
         from idmtools.builders import SimulationBuilder

--- a/idmtools_core/tests/test_platform_factory.py
+++ b/idmtools_core/tests/test_platform_factory.py
@@ -29,9 +29,9 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(entries['endpoint'], 'https://comps2.idmod.org')
 
     def test_block_not_exits(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(Exception) as context:
             Platform('NOTEXISTS')  # noqa:F841
-        self.assertTrue("NOTEXISTS is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
+        self.assertEqual("Type must be specified in Platform constructor.", str(context.exception.args[0]))
 
     @allure.story("Plugins")
     def test_bad_type(self):
@@ -41,22 +41,22 @@ class TestPlatformFactory(ITestWithPersistence):
 
     @allure.story("Plugins")
     def test_no_type(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(Exception) as context:
             Platform('NOTYPE')
-        self.assertIn('NOTYPE is an unknown Platform Type. Supported platforms are ',  context.exception.args[0])
+        self.assertIn('None is an unknown Platform Type. Supported platforms are ',  context.exception.args[0])
 
     @allure.story("Configuration")
     def test_block_is_none(self):
         try:
             Platform(None)
         except Exception as ex:
-            self.assertIn("Type must be specified in Platform constructor", ex.args[0])
+            self.assertEqual("Type must be specified in Platform constructor.", ex.args[0])
     @allure.story("Configuration")
     def test_no_block(self):
         try:
             Platform()
         except Exception as ex:
-            self.assertIn("Type must be specified in Platform constructor", ex.args[0])
+            self.assertEqual("Type must be specified in Platform constructor.", ex.args[0])
 
     @allure.story("Configuration")
     def test_create_from_block(self):
@@ -80,18 +80,24 @@ class TestPlatformFactory(ITestWithPersistence):
         platform2.cleanup()
 
     @patch("idmtools.config.idm_config_parser.user_logger")
-    def test_create_platform_with_valid_block(self, mock_user_logger):
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_valid_block(self, mock_logger, mock_user_logger):
         block = 'My_container'
         platform = Platform(block)
         self.assertEqual(platform._config_block, block)
         self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
         self.assertEqual(platform._kwargs, {})
         self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+        # verify print correct block and job_directory
+        mock_user_logger.log.call_args_list[0].assert_called_with('[My_container]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+        # verify type in block is not used
+        mock_logger.warning.call_args_list[0].assert_called_with('the following Config Settings are not used when creating Platform:')
+        mock_logger.warning.call_args_list[1].assert_called_with('- type = Container')
 
     @patch("idmtools.core.platform_factory.user_logger")
-    def test_create_platform_with_valid_block_new_job_directory_from_platform(self, mock_user_logger):
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_valid_block_new_job_directory_from_platform(self, mock_logger, mock_user_logger):
         block = 'My_container'
         platform = Platform(block, job_directory="my_directory")
         self.assertEqual(platform._config_block, block)
@@ -99,8 +105,10 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._kwargs, {'job_directory': 'my_directory'})
         # job_directory from block should be used
         self.assertIn('my_directory', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+        mock_user_logger.log.call_args_list[0].assert_called_with('[My_container]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "my_directory"')
+        mock_logger.warning.call_args_list[0].assert_called_with('the following Config Settings are not used when creating Platform:')
+        mock_logger.warning.call_args_list[1].assert_called_with('- type = Container')
 
     @patch("idmtools.core.platform_factory.user_logger")
     def test_create_platform_with_valid_block_other_kwargs(self, mock_user_logger):
@@ -111,7 +119,7 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._kwargs, {'docker_image': 'my_image'})
         # job_directory from block should be used
         self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+        mock_user_logger.log.call_args_list[0].assert_called_with('[My_container]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
 
     @patch("idmtools.core.platform_factory.user_logger")
@@ -122,91 +130,100 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._config_block, 'Container')
         self.assertEqual(platform._kwargs, kwargs)
         self.assertIn('destination_directory', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('\n[Container]')
+        # verify print correct block and job_directory
+        mock_user_logger.log.call_args_list[0].assert_called_with('[Container]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
 
-    def test_create_platform_with_invalid_block(self):
+    def test_create_platform_with_random_block(self):
         kwargs = {'job_directory': 'destination_directory'}
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(ValueError) as context:
             platform = Platform("Container1", **kwargs)
-        self.assertTrue('Container1 is an unknown Platform Type. Supported platforms are ' in str(context.exception))
+        self.assertEqual('Type must be specified in Platform constructor.', str(context.exception))
 
     @patch('idmtools.core.platform_factory.user_logger')
     @patch('idmtools.core.platform_factory.logger')
-    def test_create_platform_with_type(self, mock_logger, mock_user_logger):
-        with self.subTest("with_alias_block_and_non_used_type"):
-            kwargs = {'job_directory': 'destination_directory', 'type': 'Container1'}
-            platform = Platform("Container", **kwargs)
-            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
-            self.assertEqual(platform._config_block, 'Container')
-            self.assertEqual(platform._kwargs, kwargs)
-            self.assertIn('destination_directory', platform.job_directory)
-            mock_logger.warning.call_args_list[0].assert_called_with(f"call('\n/!\\ WARNING: The following User Inputs are not used:")
-            mock_logger.warning.call_args_list[1].assert_called_with("- type = Container1")
-            mock_user_logger.log.call_args_list[0].assert_called_with('\n[Container]')
-            mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
-        mock_logger.reset_mock()
-        mock_user_logger.reset_mock()
-        with self.subTest("with_random_block_and_valid_type"):
-            kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
-            platform = Platform("Container", **kwargs)
-            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
-            self.assertEqual(platform._config_block, 'Container')
-            self.assertEqual(platform._kwargs, kwargs)
-            self.assertIn('destination_directory', platform.job_directory)
-            mock_logger.warning.assert_not_called()
-            mock_user_logger.log.call_args_list[0].assert_called_with('\n[Container]')
-            mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
-        mock_logger.reset_mock()
-        mock_user_logger.reset_mock()
-        with self.subTest("with_no_block_and_invalid_type"):
-            with self.assertRaises(Exception) as context:
-                platform = Platform(type="Container1", job_directory="destination_directory")
-            self.assertTrue(
-                'Container1 is an unknown Platform Type. Supported platforms are ' in str(context.exception))
-        with self.subTest("with_no_block_and_valid_type"):
-            kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
-            platform = Platform(**kwargs)
-            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
-            self.assertEqual(platform._config_block, None)
-            self.assertEqual(platform._kwargs, kwargs)
-            self.assertIn('destination_directory', platform.job_directory)
-            mock_logger.warning.assert_not_called()
-            mock_user_logger.log.assert_not_called()
-        mock_user_logger.reset_mock()
-        with patch("idmtools.config.idm_config_parser.user_logger") as mock_config_user_logger:
-            with self.subTest("with_ini_block_update_type_from_ini"):
-                block = 'My_container'
-                kwargs = {'type': 'Container1'}
-                platform = Platform(block, **kwargs)
-                self.assertEqual(platform._config_block, block)
-                self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
-                self.assertEqual(platform._kwargs, kwargs)
-                self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
-                mock_logger.warning.call_args_list[0].assert_called_with(f"call('\n/!\\ WARNING: The following User Inputs are not used:")
-                mock_logger.warning.call_args_list[1].assert_called_with("- type = Container1")
-                mock_config_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
-                mock_config_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
-                mock_user_logger.log.assert_not_called()
-        mock_logger.reset_mock()
-        with self.subTest("with_non_exist_block_and_valid_type"):
-            kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+    def test_create_platform_with_alias_and_non_used_type(self, mock_logger, mock_user_logger):
+        kwargs = {'job_directory': 'destination_directory', 'type': 'Container1'}
+        platform = Platform("Container", **kwargs)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._config_block, 'Container')
+        self.assertEqual(platform._kwargs, kwargs)
+        self.assertIn('destination_directory', platform.job_directory)
+        mock_logger.warning.call_args_list[0].assert_called_with("The following User Inputs are not used:")
+        mock_logger.warning.call_args_list[1].assert_called_with("- type = Container1")
+        mock_user_logger.log.call_args_list[0].assert_called_with('[Container]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+
+    @patch('idmtools.core.platform_factory.user_logger')
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_alias_and_valid_type(self, mock_logger, mock_user_logger):
+        kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+        platform = Platform("Container", **kwargs)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._config_block, 'Container')
+        self.assertEqual(platform._kwargs, kwargs)
+        self.assertIn('destination_directory', platform.job_directory)
+        mock_user_logger.log.call_args_list[0].assert_called_with('[Container]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        mock_logger.warning.call_args_list[0].assert_called_with(
+            'WARNING: The following User Inputs are not used:')
+        mock_logger.warning.call_args_list[1].assert_called_with('- type = Container')
+
+    @patch('idmtools.core.platform_factory.user_logger')
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_no_block_and_valid_type(self, mock_logger, mock_user_logger):
+        kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+        platform = Platform(**kwargs)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._config_block, None)
+        self.assertEqual(platform._kwargs, kwargs)
+        self.assertIn('destination_directory', platform.job_directory)
+        mock_logger.warning.call_args_list[0].assert_called_with(
+            'WARNING: the following Config Settings are not used when creating Platform:')
+        mock_logger.warning.call_args_list[1].assert_called_with('- type = Container')
+    def test_create_platform_with_no_block_and_invalid_type(self):
+        with self.assertRaises(Exception) as context:
+            platform = Platform(type="Container1", job_directory="destination_directory")
+        self.assertTrue(
+            'Container1 is an unknown Platform Type. Supported platforms are ' in str(context.exception))
+
+    @patch("idmtools.config.idm_config_parser.user_logger")
+    @patch('idmtools.core.platform_factory.user_logger')
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_ini_block_update_type_from_ini(self, mock_logger, mock_user_logger, mock_config_user_logger):
+        block = 'My_container'
+        kwargs = {'type': 'Container1'}
+        platform = Platform(block, **kwargs)
+        self.assertEqual(platform._config_block, block)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._kwargs, kwargs)
+        self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
+        mock_logger.warning.call_args_list[0].assert_called_with("The following User Inputs are not used:")
+        mock_logger.warning.call_args_list[1].assert_called_with("- type = Container1")
+        mock_config_user_logger.log.call_args_list[0].assert_called_with('[My_container]')
+        mock_config_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+        mock_user_logger.log.assert_not_called()
+
+    @patch('idmtools.core.platform_factory.user_logger')
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_non_exist_block_and_valid_type(self, mock_logger, mock_user_logger):
+        kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+        platform = Platform('block', **kwargs)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._config_block, 'block')
+        self.assertEqual(platform._kwargs, kwargs)
+        self.assertIn('destination_directory', platform.job_directory)
+        mock_logger.warning.call_args_list[0].assert_called_with(
+            "the following Config Settings are not used when creating Platform:")
+        mock_logger.warning.call_args_list[1].assert_called_with("- block = block")
+        mock_user_logger.log.call_args_list[0].assert_called_with('[block]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+
+    @patch('idmtools.core.platform_factory.user_logger')
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_non_exist_block_and_valid_type(self, mock_logger, mock_user_logger):
+        kwargs = {'job_directory': 'destination_directory', 'any': 'something'}
+        with self.assertRaises(Exception) as context:
             platform = Platform('block', **kwargs)
-            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
-            self.assertEqual(platform._config_block, 'block')
-            self.assertEqual(platform._kwargs, kwargs)
-            self.assertIn('destination_directory', platform.job_directory)
-            mock_logger.warning.call_args_list[0].assert_called_with(
-                f"call('\n/!\\ WARNING: the following Config Settings are not used when creating Platform:")
-            mock_logger.warning.call_args_list[1].assert_called_with("- block = block")
-            mock_user_logger.log.call_args_list[0].assert_called_with('\n[block]')
-            mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
-        mock_user_logger.reset_mock()
-        with self.subTest("with_non_exist_block_and_valid_type"):
-            kwargs = {'job_directory': 'destination_directory', 'any': 'something'}
-            with self.assertRaises(ValueError) as context:
-                platform = Platform('block', **kwargs)
-            self.assertIn('You are specifying a platform without a configuration file or configuration block',
-                          mock_user_logger.method_calls[0].args[0])
-            self.assertTrue(
-                "block is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
+        self.assertTrue(
+            "Type must be specified in Platform constructor." in str(context.exception.args[0]))

--- a/idmtools_core/tests/test_platform_factory.py
+++ b/idmtools_core/tests/test_platform_factory.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import allure
 import os
 import pytest
@@ -29,32 +31,32 @@ class TestPlatformFactory(ITestWithPersistence):
     def test_block_not_exits(self):
         with self.assertRaises(ValueError) as context:
             Platform('NOTEXISTS')  # noqa:F841
-        self.assertEqual("Block 'NOTEXISTS' doesn't exist!", str(context.exception.args[0]))
+        self.assertTrue("NOTEXISTS is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
 
     @allure.story("Plugins")
     def test_bad_type(self):
         with self.assertRaises(ValueError) as context:
             Platform('BADTYPE')  # noqa:F841
-        self.assertTrue("Bad is an unknown Platform Type. Supported platforms are" in str(context.exception.args[0]))
+        self.assertIn("Bad is an unknown Platform Type. Supported platforms are", str(context.exception.args[0]))
 
     @allure.story("Plugins")
     def test_no_type(self):
         with self.assertRaises(ValueError) as context:
             Platform('NOTYPE')
-        self.assertIn('When creating a Platform you must specify the type in the block.', context.exception.args[0])
+        self.assertIn('NOTYPE is an unknown Platform Type. Supported platforms are ',  context.exception.args[0])
 
     @allure.story("Configuration")
     def test_block_is_none(self):
-        with self.assertRaises(ValueError) as context:
+        try:
             Platform(None)
-        self.assertIn('Must have a valid Block name to create a Platform!', context.exception.args[0])
-
+        except Exception as ex:
+            self.assertIn("Type must be specified in Platform constructor", ex.args[0])
     @allure.story("Configuration")
     def test_no_block(self):
         try:
             Platform()
         except Exception as ex:
-            self.assertIn("__new__() missing 1 required positional argument: 'block'", ex.args[0])
+            self.assertIn("Type must be specified in Platform constructor", ex.args[0])
 
     @allure.story("Configuration")
     def test_create_from_block(self):
@@ -76,3 +78,135 @@ class TestPlatformFactory(ITestWithPersistence):
         platform2.uid = None
         self.assertEqual(platform, platform2)
         platform2.cleanup()
+
+    @patch("idmtools.config.idm_config_parser.user_logger")
+    def test_create_platform_with_valid_block(self, mock_user_logger):
+        block = 'My_container'
+        platform = Platform(block)
+        self.assertEqual(platform._config_block, block)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._kwargs, {})
+        self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+
+    @patch("idmtools.core.platform_factory.user_logger")
+    def test_create_platform_with_valid_block_new_job_directory_from_platform(self, mock_user_logger):
+        block = 'My_container'
+        platform = Platform(block, job_directory="my_directory")
+        self.assertEqual(platform._config_block, block)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._kwargs, {'job_directory': 'my_directory'})
+        # job_directory from block should be used
+        self.assertIn('my_directory', platform.job_directory)
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "my_directory"')
+
+    @patch("idmtools.core.platform_factory.user_logger")
+    def test_create_platform_with_valid_block_other_kwargs(self, mock_user_logger):
+        block = 'My_container'
+        platform = Platform(block, docker_image="my_image")
+        self.assertEqual(platform._config_block, block)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._kwargs, {'docker_image': 'my_image'})
+        # job_directory from block should be used
+        self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+
+    @patch("idmtools.core.platform_factory.user_logger")
+    def test_create_platform_with_alias(self, mock_user_logger):
+        kwargs = {'job_directory': 'destination_directory'}
+        platform = Platform('Container', **kwargs)
+        self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+        self.assertEqual(platform._config_block, 'Container')
+        self.assertEqual(platform._kwargs, kwargs)
+        self.assertIn('destination_directory', platform.job_directory)
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[Container]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+
+    def test_create_platform_with_invalid_block(self):
+        kwargs = {'job_directory': 'destination_directory'}
+        with self.assertRaises(Exception) as context:
+            platform = Platform("Container1", **kwargs)
+        self.assertTrue('Container1 is an unknown Platform Type. Supported platforms are ' in str(context.exception))
+
+    @patch('idmtools.core.platform_factory.user_logger')
+    @patch('idmtools.core.platform_factory.logger')
+    def test_create_platform_with_type(self, mock_logger, mock_user_logger):
+        with self.subTest("with_alias_block_and_non_used_type"):
+            kwargs = {'job_directory': 'destination_directory', 'type': 'Container1'}
+            platform = Platform("Container", **kwargs)
+            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+            self.assertEqual(platform._config_block, 'Container')
+            self.assertEqual(platform._kwargs, kwargs)
+            self.assertIn('destination_directory', platform.job_directory)
+            mock_logger.warning.call_args_list[0].assert_called_with(f"call('\n/!\\ WARNING: The following User Inputs are not used:")
+            mock_logger.warning.call_args_list[1].assert_called_with("- type = Container1")
+            mock_user_logger.log.call_args_list[0].assert_called_with('\n[Container]')
+            mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        mock_logger.reset_mock()
+        mock_user_logger.reset_mock()
+        with self.subTest("with_random_block_and_valid_type"):
+            kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+            platform = Platform("Container", **kwargs)
+            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+            self.assertEqual(platform._config_block, 'Container')
+            self.assertEqual(platform._kwargs, kwargs)
+            self.assertIn('destination_directory', platform.job_directory)
+            mock_logger.warning.assert_not_called()
+            mock_user_logger.log.call_args_list[0].assert_called_with('\n[Container]')
+            mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        mock_logger.reset_mock()
+        mock_user_logger.reset_mock()
+        with self.subTest("with_no_block_and_invalid_type"):
+            with self.assertRaises(Exception) as context:
+                platform = Platform(type="Container1", job_directory="destination_directory")
+            self.assertTrue(
+                'Container1 is an unknown Platform Type. Supported platforms are ' in str(context.exception))
+        with self.subTest("with_no_block_and_valid_type"):
+            kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+            platform = Platform(**kwargs)
+            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+            self.assertEqual(platform._config_block, None)
+            self.assertEqual(platform._kwargs, kwargs)
+            self.assertIn('destination_directory', platform.job_directory)
+            mock_logger.warning.assert_not_called()
+            mock_user_logger.log.assert_not_called()
+        mock_user_logger.reset_mock()
+        with patch("idmtools.config.idm_config_parser.user_logger") as mock_config_user_logger:
+            with self.subTest("with_ini_block_update_type_from_ini"):
+                block = 'My_container'
+                kwargs = {'type': 'Container1'}
+                platform = Platform(block, **kwargs)
+                self.assertEqual(platform._config_block, block)
+                self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+                self.assertEqual(platform._kwargs, kwargs)
+                self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
+                mock_logger.warning.call_args_list[0].assert_called_with(f"call('\n/!\\ WARNING: The following User Inputs are not used:")
+                mock_logger.warning.call_args_list[1].assert_called_with("- type = Container1")
+                mock_config_user_logger.log.call_args_list[0].assert_called_with('\n[My_container]')
+                mock_config_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+                mock_user_logger.log.assert_not_called()
+        mock_logger.reset_mock()
+        with self.subTest("with_non_exist_block_and_valid_type"):
+            kwargs = {'job_directory': 'destination_directory', 'type': 'Container'}
+            platform = Platform('block', **kwargs)
+            self.assertEqual(platform.__class__.__name__, 'ContainerPlatform')
+            self.assertEqual(platform._config_block, 'block')
+            self.assertEqual(platform._kwargs, kwargs)
+            self.assertIn('destination_directory', platform.job_directory)
+            mock_logger.warning.call_args_list[0].assert_called_with(
+                f"call('\n/!\\ WARNING: the following Config Settings are not used when creating Platform:")
+            mock_logger.warning.call_args_list[1].assert_called_with("- block = block")
+            mock_user_logger.log.call_args_list[0].assert_called_with('\n[block]')
+            mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        mock_user_logger.reset_mock()
+        with self.subTest("with_non_exist_block_and_valid_type"):
+            kwargs = {'job_directory': 'destination_directory', 'any': 'something'}
+            with self.assertRaises(ValueError) as context:
+                platform = Platform('block', **kwargs)
+            self.assertIn('You are specifying a platform without a configuration file or configuration block',
+                          mock_user_logger.method_calls[0].args[0])
+            self.assertTrue(
+                "block is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))

--- a/idmtools_core/tests/test_platform_factory.py
+++ b/idmtools_core/tests/test_platform_factory.py
@@ -96,8 +96,8 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
         # verify print correct block and job_directory
         mock_config_user_logger.log.call_args_list[0].assert_called_with('INI File Used: ')
-        mock_user_logger.log.call_args_list[0].assert_called_with('[File_Platform]')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "MY_JOB_DIRECTORY"', mock_user_logger.log.call_args_list[1].args[1])
         # verify there is no warning printed
         mock_logger.warning.not_called()
 
@@ -111,8 +111,8 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._kwargs, {'job_directory': 'my_directory'})
         # job_directory from block should be used
         self.assertIn('my_directory', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('[File_Platform]')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "my_directory"')
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "my_directory"', mock_user_logger.log.call_args_list[1].args[1])
         # verify there is no warning printed
         mock_logger.warning.not_called()
 
@@ -125,8 +125,9 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._kwargs, {'max_job': 3})
         # job_directory from block should be used
         self.assertIn('MY_JOB_DIRECTORY', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('[File_Platform]')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "MY_JOB_DIRECTORY"')
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "MY_JOB_DIRECTORY"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"max_job": 3', mock_user_logger.log.call_args_list[1].args[1])
 
     @patch("idmtools.core.platform_factory.user_logger")
     def test_create_platform_with_alias(self, mock_user_logger):
@@ -137,8 +138,8 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._kwargs, kwargs)
         self.assertIn('destination_directory', platform.job_directory)
         # verify print correct block and job_directory
-        mock_user_logger.log.call_args_list[0].assert_called_with('[File]')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "destination_directory"', mock_user_logger.log.call_args_list[1].args[1])
 
     def test_create_platform_with_random_block(self):
         kwargs = {'job_directory': 'destination_directory'}
@@ -165,14 +166,13 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._config_block, 'File')
         self.assertEqual(platform._kwargs, kwargs)
         self.assertIn('destination_directory', platform.job_directory)
-        mock_user_logger.log.call_args_list[0].assert_called_with('[File]')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "destination_directory"', mock_user_logger.log.call_args_list[1].args[1])
         mock_logger.warning.not_called()
 
-    @patch("idmtools.config.idm_config_parser.user_logger")
     @patch('idmtools.core.platform_factory.user_logger')
     @patch('idmtools.core.platform_factory.logger')
-    def test_create_platform_valid_kwargs(self, mock_logger, mock_user_logger, mock_config_user_logger):
+    def test_create_platform_valid_kwargs(self, mock_logger, mock_user_logger):
         kwargs = {'job_directory': 'destination_directory', 'type': 'File'}
         platform = Platform(**kwargs)
         self.assertEqual(platform.__class__.__name__, 'FilePlatform')
@@ -180,9 +180,9 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._kwargs, kwargs)
         self.assertIn('destination_directory', platform.job_directory)
         # verify there is no user_logger printed from either platform_factory or idm_config_parser
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "destination_directory"', mock_user_logger.log.call_args_list[1].args[1])
         mock_logger.warning.not_called()
-        mock_user_logger.log.not_called()
-        mock_config_user_logger.log.not_called()
 
     def test_create_platform_with_no_block_and_invalid_type(self):
         with self.assertRaises(Exception) as context:
@@ -210,11 +210,8 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._config_block, 'my_block')
         self.assertEqual(platform._kwargs, kwargs)
         self.assertIn('destination_directory', platform.job_directory)
-        mock_logger.warning.call_args_list[0].assert_called_with(
-            "the following Config Settings are not used when creating Platform:")
-        mock_logger.warning.call_args_list[1].assert_called_with("- block = my_block")
-        mock_user_logger.log.call_args_list[0].assert_called_with('[my_block]')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"job_directory": "destination_directory"')
+        self.assertIn('\nInitializing FilePlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"job_directory": "destination_directory"', mock_user_logger.log.call_args_list[1].args[1])
 
     @patch('idmtools.core.platform_factory.user_logger')
     @patch('idmtools.core.platform_factory.logger')

--- a/idmtools_core/tests/test_python_simulation.py
+++ b/idmtools_core/tests/test_python_simulation.py
@@ -20,7 +20,7 @@ class TestPythonSimulation(ITestWithPersistence):
         print(self.case_name)
 
     def test_add_task_tag(self):
-        test_platform = Platform("TestExecute", type='TestExecute')
+        test_platform = Platform("Test")
         base_task = TestTask()
         sim = Simulation.from_task(base_task)
         # The tag for type is added at runtime during the pre_creation event

--- a/idmtools_core/tests/test_python_simulation.py
+++ b/idmtools_core/tests/test_python_simulation.py
@@ -20,7 +20,7 @@ class TestPythonSimulation(ITestWithPersistence):
         print(self.case_name)
 
     def test_add_task_tag(self):
-        test_platform = Platform("TestExecute", missing_ok=True)
+        test_platform = Platform("TestExecute", type='TestExecute')
         base_task = TestTask()
         sim = Simulation.from_task(base_task)
         # The tag for type is added at runtime during the pre_creation event

--- a/idmtools_models/tests/test_experiment.py
+++ b/idmtools_models/tests/test_experiment.py
@@ -25,7 +25,7 @@ model_path = os.path.abspath(os.path.join("..", "..", "examples", "python_model"
 @allure.suite("idmtools_core")
 class TestAddingSimulationsToExistingExperiment(unittest.TestCase):
     def setUp(self):
-        self.platform = Platform("TestExecute", missing_ok=True, default_missing=dict(type='TestExecute'))
+        self.platform = Platform("TestExecute", type='TestExecute')
 
     def test_adding_template_to_existing(self):
         base_task = JSONConfiguredPythonTask(script_path=model_path, python_path=sys.executable)
@@ -64,8 +64,7 @@ class TestAddingSimulationsToExistingExperiment(unittest.TestCase):
         sim = Simulation.from_task(base_task)
         exp = Experiment(disable_default_pre_create=True)
         exp.simulations.append(sim)
-        platform = Platform("TestExecute", missing_ok=True)
-        exp.pre_creation(platform=platform)
+        exp.pre_creation(platform=self.platform)
         self.assertEqual(exp.tags, {})
 
     def test_empty_experiment_template(self):

--- a/idmtools_models/tests/test_json_configured_task.py
+++ b/idmtools_models/tests/test_json_configured_task.py
@@ -84,7 +84,7 @@ class TestJSONConfiguredTask(TestCase):
     @pytest.mark.timeout(60)
     @pytest.mark.serial
     def test_reload_from_simulation_task(self):
-        with Platform("TestExecute", missing_ok=True, default_missing=dict(type='TestExecute')) as p:
+        with Platform("TestExecute", type='TestExecute') as p:
             task = ExampleExtendedJSONConfiguredTask(parameters=dict(a=1, b=2, c=3))
             experiment = Experiment.from_task(task=task, name="Test Reload Simulation")
             experiment.run(wait_until_done=True)

--- a/idmtools_models/tests/test_python_task.py
+++ b/idmtools_models/tests/test_python_task.py
@@ -112,7 +112,7 @@ class TestPythonTask(TestCase):
         Returns:
 
         """
-        with Platform("TestExecute", missing_ok=True, default_missing=dict(type='TestExecute')):
+        with Platform("TestExecute", type='TestExecute'):
             fpath = os.path.join(COMMON_INPUT_PATH, "python", "model1.py")
             # here we test a script
             params = dict(a=1, b=2, c=3)
@@ -161,7 +161,7 @@ class TestPythonTask(TestCase):
         Returns:
 
         """
-        with Platform("TestExecute", missing_ok=True, default_missing=dict(type='TestExecute')):
+        with Platform("TestExecute", type='TestExecute'):
             fpath = os.path.join(COMMON_INPUT_PATH, "python", "model1.py")
             # here we test a script that may have no config
             task = JSONConfiguredPythonTask(script_path=fpath, configfile_argument=None, python_path=sys.executable)

--- a/idmtools_models/tests/test_templated_script_task.py
+++ b/idmtools_models/tests/test_templated_script_task.py
@@ -112,7 +112,7 @@ echo Hello
 %*
 """
 
-        with Platform("TestExecute", missing_ok=True, default_missing=dict(type='TestExecute')):
+        with Platform("TestExecute", type='TestExecute'):
             wrapper_task = get_script_wrapper_windows_task(task, template_content=template)
             experiment = Experiment.from_task(wrapper_task, name=self.case_name)
             experiment.run(wait_until_done=True)
@@ -152,7 +152,7 @@ echo Hello
         """
         cmd = f"\"{sys.executable}\" -c \"import os; print(os.environ)\""
         task = CommandTask(cmd)
-        with Platform("TestExecute", missing_ok=True, default_missing=dict(type='TestExecute')):
+        with Platform("TestExecute", 'TestExecute'):
             wrapper_task = get_script_wrapper_unix_task(task, template_content=LINUX_PYTHON_PATH_WRAPPER)
             experiment = Experiment.from_task(wrapper_task, name=self.case_name)
             experiment.run(wait_until_done=True)

--- a/idmtools_models/tests/test_templated_script_task.py
+++ b/idmtools_models/tests/test_templated_script_task.py
@@ -152,7 +152,7 @@ echo Hello
         """
         cmd = f"\"{sys.executable}\" -c \"import os; print(os.environ)\""
         task = CommandTask(cmd)
-        with Platform("TestExecute", 'TestExecute'):
+        with Platform("TestExecute", type='TestExecute'):
             wrapper_task = get_script_wrapper_unix_task(task, template_content=LINUX_PYTHON_PATH_WRAPPER)
             experiment = Experiment.from_task(wrapper_task, name=self.case_name)
             experiment.run(wait_until_done=True)

--- a/idmtools_platform_comps/tests/idmtools.ini
+++ b/idmtools_platform_comps/tests/idmtools.ini
@@ -12,10 +12,10 @@ max_local_sims = 6
 [COMPS]
 type = COMPS
 endpoint = https://comps.idmod.org
-environment = Belegost
+environment = CALCULON
 priority = Lowest
 simulation_root = $COMPS_PATH(USER)\output
-node_group = emod_abcd
+node_group = idm_abcd
 num_retries = 0
 num_cores = 1
 max_workers = 16
@@ -25,10 +25,10 @@ exclusive = False
 [COMPS2]
 type = COMPS
 endpoint = https://comps2.idmod.org
-environment = Bayesian
+environment = SlurmStage
 priority = Normal
 simulation_root = $COMPS_PATH(USER)\output
-node_group = emod_8cores
+node_group = idm_48cores
 num_retries = 0
 num_cores = 1
 max_workers = 16

--- a/idmtools_platform_comps/tests/test_no_config.py
+++ b/idmtools_platform_comps/tests/test_no_config.py
@@ -43,15 +43,15 @@ class TestNoConfig(unittest.TestCase):
         os.chdir(cls.current_directory)
         IdmConfigParser.clear_instance()
 
-    @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+    @unittest.mock.patch("idmtools.config.idm_config_parser.logger")
     @pytest.mark.comps
     @pytest.mark.serial
     @run_in_temp_dir
-    def test_success(self, output):
+    def test_success(self, mock_logger):
         logger.info(f'Current Directory: {os.getcwd()}')
         logger.info(f'Current idmtools file: {IdmConfigParser.get_config_path()}')
         sim_root_dir = os.path.join('$COMPS_PATH(USER)', 'output')
-        plat_obj = Platform('COMPS',
+        plat_obj = Platform('SlurmStage',
                             endpoint='https://comps2.idmod.org',
                             environment='SlurmStage',
                             priority='Normal',
@@ -66,16 +66,16 @@ class TestNoConfig(unittest.TestCase):
             experiment = Experiment.from_id('73ba8f3b-8848-ee11-92fb-f0921c167864')
         except:  # noqa: E722
             pass
-        self.assertIn("File 'idmtools.ini' Not Found!", output.getvalue())
+        mock_logger.warning.call_args_list[0].assert_called_with("File 'idmtools.ini' Not Found!")
 
     @pytest.mark.comps
-    @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+    @unittest.mock.patch("idmtools.config.idm_config_parser.logger")
     @run_in_temp_dir
-    def test_failure(self, output):
+    def test_failure(self, mock_logger):
         logger.info(f'Current Directory: {os.getcwd()}')
         sim_root_dir = os.path.join('$COMPS_PATH(USER)', 'output')
         with self.assertRaises(ValueError) as a:
-            plat_obj = Platform('COMPS',
+            plat_obj = Platform('SlurmStage',
                                 endpoint='https://comps2.idmod.org',
                                 environment='SlurmStage',
                                 priority='Normal',
@@ -85,17 +85,17 @@ class TestNoConfig(unittest.TestCase):
                                 num_retries='0',
                                 exclusive='False', missing_ok=True)
             experiment = Experiment.from_id('73ba8f3b-8848-ee11-92fb-f0921c167864')
-        self.assertIn("File 'idmtools.ini' Not Found!", output.getvalue())
+        mock_logger.warning.call_args_list[0].assert_called_with("File 'idmtools.ini' Not Found!")
         # Need to identify how to capture output after log changes
         # self.assertIn("The field num_cores requires a value of type int. You provided <abc>", output.getvalue())
 
     @pytest.mark.comps
-    @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+    @unittest.mock.patch("idmtools.config.idm_config_parser.logger")
     @run_in_temp_dir
-    def test_env_success(self, output):
+    def test_env_success(self, mock_logger):
         logger.info(f'Current Directory: {os.getcwd()}')
         sim_root_dir = os.path.join('$COMPS_PATH(USER)', 'output')
-        plat_obj = Platform('COMPS',
+        plat_obj = Platform('SlurmStage',
                             endpoint='https://comps2.idmod.org',
                             environment='SlurmStage',
                             priority='Normal',
@@ -112,6 +112,6 @@ class TestNoConfig(unittest.TestCase):
             # ignore error is it is comps error about not finding id
             if "404 Not Found" in ex.args[0]:
                 pass
-        self.assertIn("File 'idmtools.ini' Not Found!", output.getvalue())
+        mock_logger.warning.call_args_list[0].assert_called_with("File 'idmtools.ini' Not Found!")
         # Need to identify how to capture output after log changes
         # self.assertIn("The field num_cores requires a value of type int. You provided <abc>", output.getvalue())

--- a/idmtools_platform_comps/tests/test_no_config.py
+++ b/idmtools_platform_comps/tests/test_no_config.py
@@ -59,7 +59,7 @@ class TestNoConfig(unittest.TestCase):
                             priority='Normal',
                             simulation_root=sim_root_dir,
                             node_group='idm_abcd',
-                            num_cores='1',
+                            num_cores=1,
                             num_retries='0',
                             exclusive='False', missing_ok=True)
 
@@ -69,9 +69,15 @@ class TestNoConfig(unittest.TestCase):
         except:  # noqa: E722
             pass
         mock_config_logger.warning.call_args_list[0].assert_called_with("File 'idmtools.ini' Not Found!")
-        mock_user_logger.log.call_args_list[0].assert_called_with("\n[SlurmStage]")
-        mock_user_logger.log.call_args_list[1].assert_called_with('"endpoint": "http://comps2.idmod.org"')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "SlurmStage"')
+        self.assertIn('\nInitializing COMPSPlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"endpoint": "https://comps2.idmod.org"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"environment": "SlurmStage"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"node_group": "idm_abcd"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"num_cores": 1', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"priority": "Normal"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"exclusive": false', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"num_retries": 0', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"simulation_root": "$COMPS_PATH(USER)', mock_user_logger.log.call_args_list[1].args[1])
         mock_logger.warning.call_args_list[0].assert_called_with(
             "the following Config Settings are not used when creating Platform:")
         mock_logger.warning.call_args_list[1].assert_called_with("- missing_ok = True")
@@ -120,9 +126,15 @@ class TestNoConfig(unittest.TestCase):
             # ignore error is it is comps error about not finding id
             if "404 Not Found" in ex.args[0]:
                 pass
-        mock_user_logger.log.call_args_list[0].assert_called_with("\n[SlurmStage]")
-        mock_user_logger.log.call_args_list[1].assert_called_with('"endpoint": "http://comps2.idmod.org"')
-        mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "SlurmStage"')
+        self.assertIn('\nInitializing COMPSPlatform with:', mock_user_logger.log.call_args_list[0].args[1])
+        self.assertIn('"endpoint": "https://comps2.idmod.org"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"environment": "SlurmStage"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"node_group": "idm_abcd"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"num_cores": 1', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"priority": "Normal"', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"exclusive": false', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"num_retries": 0', mock_user_logger.log.call_args_list[1].args[1])
+        self.assertIn('"simulation_root": "$COMPS_PATH(USER)', mock_user_logger.log.call_args_list[1].args[1])
         mock_logger.warning.call_args_list[0].assert_called_with(
             "the following Config Settings are not used when creating Platform:")
         mock_logger.warning.call_args_list[1].assert_called_with("- missing_ok = True")

--- a/idmtools_platform_comps/tests/test_platform_factory.py
+++ b/idmtools_platform_comps/tests/test_platform_factory.py
@@ -24,6 +24,12 @@ class TestPlatformFactory(ITestWithPersistence):
     def tearDown(self):
         super().tearDown()
 
+    def run_python_version(self, name):
+        command = "python3 --version"
+        task = CommandTask(command=command)
+        experiment = Experiment.from_task(task, name=name)
+        return experiment
+
     @pytest.mark.comps
     @pytest.mark.timeout(60)
     @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
@@ -128,7 +134,6 @@ class TestPlatformFactory(ITestWithPersistence):
         mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "Calculon"')
         mock_logger.warning.not_called()
 
-
     @pytest.mark.comps
     @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
     def test_platform_factory_with_random_block_and_valid_platform_fields(self, mock_login):
@@ -158,53 +163,68 @@ class TestPlatformFactory(ITestWithPersistence):
 
     @pytest.mark.comps
     @pytest.mark.timeout(60)
-    def test_with_experiment(self):
-        def run_python_version(name):
-            command = "python3 --version"
-            task = CommandTask(command=command)
-            experiment = Experiment.from_task(task, name=name)
-            return experiment
-        with self.subTest("test_with_alias"):
-            platform = Platform('SlurmStage')
-            exp = run_python_version("test_with_alias")
-            exp.run(wait_until_done=True, platform=platform)
-            self.assertTrue(exp.succeeded)
-        with self.subTest("test_with_ini"):
-            platform = Platform('COMPS2')
-            exp = run_python_version("test_with_ini")
-            exp.run(wait_until_done=True, platform=platform)
-            self.assertTrue(exp.succeeded)
-        with self.subTest("test_with_no_block"):
-            platform = Platform(endpoint='https://comps2.idmod.org', environment='SlurmStage', type='COMPS')
-            exp = run_python_version("test_with_no_block")
-            exp.run(wait_until_done=True, platform=platform)
-            self.assertTrue(exp.succeeded)
-        with self.subTest("test_with_block_and_valid_fields"):
-            platform = Platform("my_block", endpoint='https://comps2.idmod.org', environment='SlurmStage', type='COMPS')
-            exp = run_python_version("test_with_block_and_valid_fields")
-            exp.run(wait_until_done=True, platform=platform)
-            self.assertTrue(exp.succeeded)
-        with self.subTest("test_with_ini_and_update"):
-            platform = Platform('COMPS2', node_group="idm_abcd")
-            exp = run_python_version("test_with_ini_and_update")
-            exp.run(wait_until_done=True, platform=platform)
-            self.assertTrue(exp.succeeded)
-        with self.subTest("test_with_ini_and_invalid_update"):
-            with self.assertRaises(RuntimeError) as context:
-                platform = Platform('COMPS2', environment="Calculon")
-                exp = run_python_version("test_with_ini_and_invalid_update")
-                exp.run(platform=platform)
-            self.assertTrue("invalid environment-name: Calculon" in str(context.exception.args[0]))
-        with self.subTest("test_with_no_type_no_block"):
-            with self.assertRaises(Exception) as context:
-                platform = Platform(endpoint='https://comps2.idmod.org', environment='SlurmStage')
-                exp = run_python_version("test_with_no_type_no_block")
-                exp.run(platform=platform)
-            self.assertEqual("Type must be specified in Platform constructor.", str(context.exception.args[0]))
-        with self.subTest("test_no_alias_block"):
-            with self.assertRaises(ValueError) as context:
-                platform = Platform(block="SlurmStage1")
-                exp = run_python_version("test_no_alias_block")
-                exp.run(platform=platform)
-            self.assertTrue("Type must be specified in Platform constructor." in str(context.exception.args[0]))
+    def test_with_experiment_with_alias(self):
+        platform = Platform('SlurmStage')
+        exp = self.run_python_version("test_with_alias")
+        exp.run(wait_until_done=True, platform=platform)
+        self.assertTrue(exp.succeeded)
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_ini(self):
+        platform = Platform('COMPS2')
+        exp = self.run_python_version("test_with_ini")
+        exp.run(wait_until_done=True, platform=platform)
+        self.assertTrue(exp.succeeded)
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_no_block(self):
+        platform = Platform(endpoint='https://comps2.idmod.org', environment='SlurmStage', type='COMPS')
+        exp = self.run_python_version("test_with_no_block")
+        exp.run(wait_until_done=True, platform=platform)
+        self.assertTrue(exp.succeeded)
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_block_and_valid_fields(self):
+        platform = Platform("my_block", endpoint='https://comps2.idmod.org', environment='SlurmStage', type='COMPS')
+        exp = self.run_python_version("test_with_block_and_valid_fields")
+        exp.run(wait_until_done=True, platform=platform)
+        self.assertTrue(exp.succeeded)
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_ini_and_update(self):
+        platform = Platform('COMPS2', node_group="idm_abcd")
+        exp = self.run_python_version("test_with_ini_and_update")
+        exp.run(wait_until_done=True, platform=platform)
+        self.assertTrue(exp.succeeded)
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_ini_and_invalid_update(self):
+        with self.assertRaises(RuntimeError) as context:
+            platform = Platform('COMPS2', environment="Calculon")
+            exp = self.run_python_version("test_with_ini_and_invalid_update")
+            exp.run(platform=platform)
+        self.assertTrue("invalid environment-name: Calculon" in str(context.exception.args[0]))
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_no_type_no_block(self):
+        with self.assertRaises(Exception) as context:
+            platform = Platform(endpoint='https://comps2.idmod.org', environment='SlurmStage')
+            exp = self.run_python_version("test_with_no_type_no_block")
+            exp.run(platform=platform)
+        self.assertEqual("Type must be specified in Platform constructor.", str(context.exception.args[0]))
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment_with_no_alias_block(self):
+        with self.assertRaises(ValueError) as context:
+            platform = Platform(block="My_Stage")
+            exp = self.run_python_version("test_no_alias_block")
+            exp.run(platform=platform)
+        self.assertTrue("Type must be specified in Platform constructor." in str(context.exception.args[0]))
 

--- a/idmtools_platform_comps/tests/test_platform_factory.py
+++ b/idmtools_platform_comps/tests/test_platform_factory.py
@@ -208,7 +208,6 @@ class TestPlatformFactory(ITestWithPersistence):
             platform = Platform('COMPS2', environment="Calculon")
             exp = self.run_python_version("test_with_ini_and_invalid_update")
             exp.run(platform=platform)
-        print(str(context.exception.args[0]))
         self.assertTrue("invalid environment-name: Calculon" in str(context.exception.args[0]))
 
     @pytest.mark.comps

--- a/idmtools_platform_comps/tests/test_platform_factory.py
+++ b/idmtools_platform_comps/tests/test_platform_factory.py
@@ -208,6 +208,7 @@ class TestPlatformFactory(ITestWithPersistence):
             platform = Platform('COMPS2', environment="Calculon")
             exp = self.run_python_version("test_with_ini_and_invalid_update")
             exp.run(platform=platform)
+        print(str(context.exception.args[0]))
         self.assertTrue("invalid environment-name: Calculon" in str(context.exception.args[0]))
 
     @pytest.mark.comps

--- a/idmtools_platform_comps/tests/test_platform_factory.py
+++ b/idmtools_platform_comps/tests/test_platform_factory.py
@@ -5,6 +5,8 @@ import pytest
 from dataclasses import fields
 from idmtools.config import IdmConfigParser
 from idmtools.core.platform_factory import Platform
+from idmtools.entities.command_task import CommandTask
+from idmtools.entities.experiment import Experiment
 from idmtools_test.utils.itest_with_persistence import ITestWithPersistence
 
 
@@ -64,4 +66,144 @@ class TestPlatformFactory(ITestWithPersistence):
         platform.uid = None
         platform2.uid = None
         self.assertEqual(platform, platform2)
+
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_unkown_platform(self, mock_login):
+        with self.assertRaises(ValueError) as context:
+            platform = Platform('COMPS1', endpoint='https://comps.idmod.org', environment='Calculon')
+        self.assertTrue(
+            "COMPS1 is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_ini(self, mock_login):
+        platform = Platform('COMPS2')
+        self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
+        self.assertEqual(platform.endpoint, 'https://comps2.idmod.org')
+        self.assertEqual(platform.environment, 'SlurmStage')
+
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_ini_and_update_required_fields(self, mock_login):
+        # this case we first get all fields in COMPS2 block, then update endpoint and environment fields to new values
+        # since type is just happen to the same, so we can create new platform object with these 3 new values
+        platform = Platform('COMPS2', endpoint='https://comps.idmod.org', environment='Calculon')
+        self.assertEqual(platform.endpoint, 'https://comps.idmod.org')
+        self.assertEqual(platform.environment, 'Calculon')
+
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools.core.platform_factory.user_logger')
+    @unittest.mock.patch('idmtools.core.platform_factory.logger')
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_ini_and_update_random_field(self, mock_login, mock_logger, mock_user_logger):
+        platform = Platform('COMPS2', endpoint='https://comps.idmod.org', node='abcd')
+        self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
+        self.assertEqual(platform._config_block, 'COMPS2')
+        mock_logger.warning.call_args_list[0].assert_called_with(
+            f"call('\n/!\\ WARNING: The following User Inputs are not used:")
+        mock_logger.warning.call_args_list[1].assert_called_with("- node = abcd")
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[COMPS2]')
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools.core.platform_factory.user_logger')
+    @unittest.mock.patch('idmtools.core.platform_factory.logger')
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_ini_and_update_valid_field(self, mock_login, mock_logger, mock_user_logger):
+        platform = Platform('COMPS2', environment='Calculon')
+        self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
+        self.assertEqual(platform._config_block, 'COMPS2')
+        mock_logger.warning.assert_not_called()
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[COMPS2]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "Calculon"')
+
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools.core.platform_factory.user_logger')
+    @unittest.mock.patch('idmtools.core.platform_factory.logger')
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_ini_and_update_valid_field(self, mock_login, mock_logger, mock_user_logger):
+        platform = Platform('COMPS2', environment='Calculon')
+        self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
+        self.assertEqual(platform._config_block, 'COMPS2')
+        mock_logger.warning.assert_not_called()
+        mock_user_logger.log.call_args_list[0].assert_called_with('\n[COMPS2]')
+        mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "Calculon"')
+
+
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_random_block_and_valid_platform_fields(self, mock_login):
+        kwargs = {'endpoint':'https://comps.idmod.org', 'environment': 'Calculon', 'type': 'COMPS'}
+        platform = Platform('COMPS1', **kwargs)
+        self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
+        self.assertEqual(platform._config_block, 'COMPS1')
+        self.assertEqual(platform._kwargs, kwargs)
+
+    # After bug fix 2313
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_lowercase_type_value(self, mock_login):
+        kwargs = {'endpoint':'https://comps.idmod.org', 'environment': 'Calculon', 'type': 'comps'}
+        platform = Platform('COMPS1', **kwargs)
+        self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
+        self.assertEqual(platform._config_block, 'COMPS1')
+        self.assertEqual(platform._kwargs, kwargs)
+
+    @pytest.mark.comps
+    @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
+    def test_platform_factory_with_no_exist_block_no_type(self, mock_login):
+        kwargs = {'endpoint':'https://comps2.idmod.org', 'environment': 'SlurmStage'}
+        with self.assertRaises(ValueError) as context:
+            platform = Platform("my_block", **kwargs)
+            self.assertIn("my_block is an unknown Platform Type. Supported platforms are", str(context.exception.args[0]))
+
+    @pytest.mark.comps
+    @pytest.mark.timeout(60)
+    def test_with_experiment(self):
+        def run_python_version(name):
+            command = "python3 --version"
+            task = CommandTask(command=command)
+            experiment = Experiment.from_task(task, name=name)
+            return experiment
+        with self.subTest("test_with_alias"):
+            platform = Platform('SlurmStage')
+            exp = run_python_version("test_with_alias")
+            exp.run(wait_until_done=True, platform=platform)
+            self.assertTrue(exp.succeeded)
+        with self.subTest("test_with_ini"):
+            platform = Platform('COMPS2')
+            exp = run_python_version("test_with_ini")
+            exp.run(wait_until_done=True, platform=platform)
+            self.assertTrue(exp.succeeded)
+        with self.subTest("test_with_no_block"):
+            platform = Platform(endpoint='https://comps2.idmod.org', environment='SlurmStage', type='COMPS')
+            exp = run_python_version("test_with_no_block")
+            exp.run(wait_until_done=True, platform=platform)
+            self.assertTrue(exp.succeeded)
+        with self.subTest("test_with_block_and_valid_fields"):
+            platform = Platform("my_block", endpoint='https://comps2.idmod.org', environment='SlurmStage', type='COMPS')
+            exp = run_python_version("test_with_block_and_valid_fields")
+            exp.run(wait_until_done=True, platform=platform)
+            self.assertTrue(exp.succeeded)
+        with self.subTest("test_with_ini_and_update"):
+            platform = Platform('COMPS2', node_group="idm_abcd")
+            exp = run_python_version("test_with_ini_and_update")
+            exp.run(wait_until_done=True, platform=platform)
+            self.assertTrue(exp.succeeded)
+        with self.subTest("test_with_ini_and_invalid_update"):
+            with self.assertRaises(RuntimeError) as context:
+                platform = Platform('COMPS2', environment="Calculon")
+                exp = run_python_version("test_with_ini_and_invalid_update")
+                exp.run(platform=platform)
+            self.assertTrue("invalid environment-name: Calculon" in str(context.exception.args[0]))
+        with self.subTest("test_with_no_type_no_block"):
+            with self.assertRaises(Exception) as context:
+                platform = Platform(endpoint='https://comps2.idmod.org', environment='SlurmStage')
+                exp = run_python_version("test_with_no_type_no_block")
+                exp.run(platform=platform)
+            self.assertEqual("Type must be specified in Platform constructor.", str(context.exception.args[0]))
+        with self.subTest("test_no_alias_block"):
+            with self.assertRaises(ValueError) as context:
+                platform = Platform(block="SlurmStage1")
+                exp = run_python_version("test_no_alias_block")
+                exp.run(platform=platform)
+            self.assertTrue("SlurmStage1 is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
 

--- a/idmtools_platform_comps/tests/test_platform_factory.py
+++ b/idmtools_platform_comps/tests/test_platform_factory.py
@@ -126,8 +126,7 @@ class TestPlatformFactory(ITestWithPersistence):
         self.assertEqual(platform._config_block, 'COMPS2')
         mock_user_logger.log.call_args_list[0].assert_called_with('\n[COMPS2]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "Calculon"')
-        mock_logger.warning.call_args_list[0].assert_called_with("WARNING: the following Config Settings are not used when creating Platform:")
-        mock_logger.warning.call_args_list[1].assert_called_with("- type = Container")
+        mock_logger.warning.not_called()
 
 
     @pytest.mark.comps

--- a/idmtools_platform_comps/tests/test_platform_factory.py
+++ b/idmtools_platform_comps/tests/test_platform_factory.py
@@ -73,7 +73,7 @@ class TestPlatformFactory(ITestWithPersistence):
         with self.assertRaises(ValueError) as context:
             platform = Platform('COMPS1', endpoint='https://comps.idmod.org', environment='Calculon')
         self.assertTrue(
-            "COMPS1 is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
+            "Type must be specified in Platform constructor." in str(context.exception.args[0]))
     @pytest.mark.comps
     @unittest.mock.patch('idmtools_platform_comps.comps_platform.COMPSPlatform._login', side_effect=lambda: True)
     def test_platform_factory_with_ini(self, mock_login):
@@ -111,7 +111,8 @@ class TestPlatformFactory(ITestWithPersistence):
         platform = Platform('COMPS2', environment='Calculon')
         self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
         self.assertEqual(platform._config_block, 'COMPS2')
-        mock_logger.warning.assert_not_called()
+        mock_logger.warning.call_args_list[0].assert_called_with("The following User Inputs are not used:")
+        mock_logger.warning.call_args_list[1].assert_called_with("- type = Container")
         mock_user_logger.log.call_args_list[0].assert_called_with('\n[COMPS2]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "Calculon"')
 
@@ -123,9 +124,10 @@ class TestPlatformFactory(ITestWithPersistence):
         platform = Platform('COMPS2', environment='Calculon')
         self.assertEqual(platform.__class__.__name__, 'COMPSPlatform')
         self.assertEqual(platform._config_block, 'COMPS2')
-        mock_logger.warning.assert_not_called()
         mock_user_logger.log.call_args_list[0].assert_called_with('\n[COMPS2]')
         mock_user_logger.log.call_args_list[1].assert_called_with('"environment": "Calculon"')
+        mock_logger.warning.call_args_list[0].assert_called_with("WARNING: the following Config Settings are not used when creating Platform:")
+        mock_logger.warning.call_args_list[1].assert_called_with("- type = Container")
 
 
     @pytest.mark.comps
@@ -205,5 +207,5 @@ class TestPlatformFactory(ITestWithPersistence):
                 platform = Platform(block="SlurmStage1")
                 exp = run_python_version("test_no_alias_block")
                 exp.run(platform=platform)
-            self.assertTrue("SlurmStage1 is an unknown Platform Type. Supported platforms are " in str(context.exception.args[0]))
+            self.assertTrue("Type must be specified in Platform constructor." in str(context.exception.args[0]))
 


### PR DESCRIPTION
- Fix #1655 
- Fix #2325 

Summary for platform_factory:

- **Block**: An optional string parameter.
- **Platform Type Resolution**:
- **Alias** Check: If block is an alias, resolve the platform_type from the alias.
- **INI** File Check: If block is specified in the INI file, retrieve the platform_type from the INI file.
- **Default**: If neither of the above, use the type from the platform constructor.
- **Parameter Precedence**: All platform constructor parameters take precedence, allowing them to override values defined in either the platform specification or the INI file.
