### PR TITLE
Add setuptools to requirements.txt in core for python3.12

### DIFF
--- a/idmtools_core/requirements.txt
+++ b/idmtools_core/requirements.txt
@@ -11,4 +11,4 @@ tabulate>=0.8.9,<0.10
 tqdm>=4.52.0,<5
 jinja2~=3.1.3
 packaging>=20.4,<25.0
-
+setuptools


### PR DESCRIPTION
python3.12 does not have setuptools installed by default. we may want to add this to core