### PR TITLE
override _object_cache_expiration value from 60s to 600s for slurm and container platforms

### DIFF
--- a/idmtools_platform_general/idmtools_platform_file/file_platform.py
+++ b/idmtools_platform_general/idmtools_platform_file/file_platform.py
@@ -57,7 +57,6 @@ class FilePlatform(IPlatform):
     _simulations: FilePlatformSimulationOperations = field(**op_defaults, repr=False, init=False)
     _assets: FilePlatformAssetCollectionOperations = field(**op_defaults, repr=False, init=False)
     _metas: JSONMetadataOperations = field(**op_defaults, repr=False, init=False)
-    _object_cache_expiration: 'int' = field(default=600, repr=False, init=False)
 
     def __post_init__(self):
         self.__init_interfaces()
@@ -69,6 +68,7 @@ class FilePlatform(IPlatform):
         self.sim_name_directory = IdmConfigParser.get_option(None, "sim_name_directory",
                                                              'False').lower() in TRUTHY_VALUES
         super().__post_init__()
+        self._object_cache_expiration = 600
 
     def __init_interfaces(self):
         self._suites = FilePlatformSuiteOperations(platform=self)

--- a/idmtools_platform_general/idmtools_platform_file/file_platform.py
+++ b/idmtools_platform_general/idmtools_platform_file/file_platform.py
@@ -57,6 +57,7 @@ class FilePlatform(IPlatform):
     _simulations: FilePlatformSimulationOperations = field(**op_defaults, repr=False, init=False)
     _assets: FilePlatformAssetCollectionOperations = field(**op_defaults, repr=False, init=False)
     _metas: JSONMetadataOperations = field(**op_defaults, repr=False, init=False)
+    _object_cache_expiration: 'int' = field(default=600, repr=False, init=False)
 
     def __post_init__(self):
         self.__init_interfaces()

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -126,7 +126,7 @@ class SlurmPlatform(IPlatform):
     _assets: SlurmPlatformAssetCollectionOperations = field(**op_defaults, repr=False, init=False)
     _metas: JSONMetadataOperations = field(**op_defaults, repr=False, init=False)
     _op_client: SlurmOperations = field(**op_defaults, repr=False, init=False)
-    _object_cache_expiration: 'int' = field(default=600, repr=False, init=False)
+
     def __post_init__(self):
         if isinstance(self.mode, str):
             if self.mode.upper() not in [mode.value.upper() for mode in SlurmOperationalMode]:
@@ -155,6 +155,7 @@ class SlurmPlatform(IPlatform):
             raise ValueError(f"Invalid mpi_type '{self.mpi_type}'. Allowed values are 'pmi2', 'pmix', or 'mpirun'.")
 
         super().__post_init__()
+        self._object_cache_expiration = 600
 
         # check if run script as a slurm job
         r = run_script_on_slurm(self, run_on_slurm=self.run_on_slurm)

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -126,7 +126,7 @@ class SlurmPlatform(IPlatform):
     _assets: SlurmPlatformAssetCollectionOperations = field(**op_defaults, repr=False, init=False)
     _metas: JSONMetadataOperations = field(**op_defaults, repr=False, init=False)
     _op_client: SlurmOperations = field(**op_defaults, repr=False, init=False)
-
+    _object_cache_expiration: 'int' = field(default=600, repr=False, init=False)
     def __post_init__(self):
         if isinstance(self.mode, str):
             if self.mode.upper() not in [mode.value.upper() for mode in SlurmOperationalMode]:


### PR DESCRIPTION
Fixed #2391 