### PR TITLE
Make slurm IDM tools compatible  with NYU's Cluster

### DIFF
--- a/dev_scripts/run_pymake_on_all.py
+++ b/dev_scripts/run_pymake_on_all.py
@@ -31,5 +31,7 @@ if __name__ == '__main__':
     # fallback to os default
     else:
         raise FileNotFoundError("Cannot find make. If you are on Windows, run pip install almake or pip install py-make. On Linux install make")
-    print(f'python {os.path.join(base_directory, "dev_scripts", "run_all.py")} {env_str} {p_str}--exec "{make_command} {args.command}"')
-    sys.exit(os.system(f'python {os.path.join(base_directory, "dev_scripts", "run_all.py")} {env_str} {p_str}--exec "{make_command} {args.command}"'))
+    
+    cmd = f'python "{os.path.join(base_directory, "dev_scripts", "run_all.py")}" {env_str} {p_str}--exec "{make_command} {args.command}"'
+    print(cmd)
+    sys.exit(os.system(cmd))

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/__init__.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/__init__.py
@@ -67,6 +67,9 @@ def generate_batch(platform: 'SlurmPlatform', experiment: Experiment,
         dependency = True
     template_vars['dependency'] = dependency
 
+    # Control propagation of inherited SLURM env vars into downstream scripts
+    template_vars['propogate_slurm_env_var'] = getattr(platform, 'propogate_slurm_env_var', True)
+
     # Update with possible override values
     template_vars.update(kwargs)
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/__init__.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/__init__.py
@@ -68,7 +68,7 @@ def generate_batch(platform: 'SlurmPlatform', experiment: Experiment,
     template_vars['dependency'] = dependency
 
     # Control propagation of inherited SLURM env vars into downstream scripts
-    template_vars['propogate_slurm_env_var'] = getattr(platform, 'propogate_slurm_env_var', True)
+    template_vars['propagate_slurm_env_var'] = getattr(platform, 'propagate_slurm_env_var', True)
 
     # Update with possible override values
     template_vars.update(kwargs)

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+{% if not propogate_slurm_env_var %}
+unset SLURM_JOB_ID
+unset SLURM_CPU_BIND
+unset SLURM_CPU_BIND_TYPE
+unset SLURM_JOB_NODELIST
+unset SLURM_NODELIST
+unset SLURM_NNODES
+unset SLURM_NTASKS
+unset SLURM_TASKS_PER_NODE
+unset SLURM_MEM_PER_CPU
+unset SLURM_MEM_PER_NODE
+{% endif %}
+
 # Set the total number of tasks
 total_tasks={{njobs}}
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/assets/batch.sh.jinja2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{% if not propogate_slurm_env_var %}
+{% if not propagate_slurm_env_var %}
 unset SLURM_JOB_ID
 unset SLURM_CPU_BIND
 unset SLURM_CPU_BIND_TYPE

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -95,6 +95,10 @@ class SlurmPlatform(FilePlatform):
     # Set array max size for Slurm job
     array_batch_size: int = field(default=None, metadata=dict(sbatch=False, help="Array batch size"))
 
+    # Toggle propagation of inherited SLURM env vars into generated scripts
+    propogate_slurm_env_var: bool = field(default=True, metadata=dict(sbatch=False,
+                                                                     help="Keep SLURM env vars available to child scripts"))
+
     # determine if run script as Slurm job
     run_on_slurm: bool = field(default=False, repr=False, compare=False, metadata=dict(help="Run script as Slurm job"))
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -95,7 +95,10 @@ class SlurmPlatform(FilePlatform):
     # Set array max size for Slurm job
     array_batch_size: int = field(default=None, metadata=dict(sbatch=False, help="Array batch size"))
 
-    # Toggle propagation of inherited SLURM env vars into generated scripts
+    # Toggle propagation of inherited SLURM env vars into generated scripts. 
+    # If running idmtools from an allocated partition, you likely want to change 
+    # this to False to avoid issues with child jobs inheriting
+    # SLURM env vars from your interactive terminal.
     propogate_slurm_env_var: bool = field(default=True, metadata=dict(sbatch=False,
                                                                      help="Keep SLURM env vars available to child scripts"))
 

--- a/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
+++ b/idmtools_platform_slurm/idmtools_platform_slurm/slurm_platform.py
@@ -99,7 +99,7 @@ class SlurmPlatform(FilePlatform):
     # If running idmtools from an allocated partition, you likely want to change 
     # this to False to avoid issues with child jobs inheriting
     # SLURM env vars from your interactive terminal.
-    propogate_slurm_env_var: bool = field(default=True, metadata=dict(sbatch=False,
+    propagate_slurm_env_var: bool = field(default=True, metadata=dict(sbatch=False,
                                                                      help="Keep SLURM env vars available to child scripts"))
 
     # determine if run script as Slurm job
@@ -120,6 +120,10 @@ class SlurmPlatform(FilePlatform):
 
     def __post_init__(self):
         super().__post_init__()
+        # Preserve backwards compatibility with legacy config key
+        if hasattr(self, 'propogate_slurm_env_var'):
+            self.propagate_slurm_env_var = getattr(self, 'propogate_slurm_env_var')
+            delattr(self, 'propogate_slurm_env_var')
         self.__init_interfaces()
 
         # check max_array_size from slurm configuration

--- a/idmtools_platform_slurm/pyproject.toml
+++ b/idmtools_platform_slurm/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "idmtools_platform_general~=3.0.0",
+    "idmtools~=3.0.0",
     "dataclasses-json",
 ]
 

--- a/idmtools_platform_slurm/pyproject.toml
+++ b/idmtools_platform_slurm/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "idmtools~=3.0.0",
+    "idmtools_platform_general~=3.0",
     "dataclasses-json",
 ]
 

--- a/idmtools_platform_slurm/tests/test_slurm_operations.py
+++ b/idmtools_platform_slurm/tests/test_slurm_operations.py
@@ -26,6 +26,46 @@ class TestSlurmOperations(ITestWithPersistence):
     def setUp(self) -> None:
         self.platform = Platform('SLURM_LOCAL')
 
+    def _generate_batch_from_simtools_config(self, extra_config_lines=None):
+        """Create a batch file using a temporary simtools.ini and return its contents."""
+        original_config = os.environ.get("IDMTOOLS_CONFIG_FILE")
+        IdmConfigParser.clear_instance()
+        contents = None
+        with tempfile.TemporaryDirectory() as temp_dir:
+            job_dir = os.path.join(temp_dir, "jobs")
+            os.makedirs(job_dir, exist_ok=True)
+            simtools_ini = os.path.join(temp_dir, "simtools.ini")
+            config_lines = [
+                "[SLURM_SIMTOOLS]",
+                "type = Slurm",
+                f"job_directory = {job_dir}",
+            ]
+            if extra_config_lines:
+                config_lines.extend(extra_config_lines)
+            with open(simtools_ini, "w") as config_file:
+                config_file.write("\n".join(config_lines))
+            os.environ["IDMTOOLS_CONFIG_FILE"] = simtools_ini
+            IdmConfigParser.clear_instance()
+            try:
+                platform = Platform('SLURM_SIMTOOLS')
+                slurm_op = SlurmOperations(platform=platform)
+                suite = Suite(name="Suite")
+                experiment = Experiment(name="ExpSimtools")
+                experiment.parent = suite
+                slurm_op.mk_directory(experiment)
+                slurm_op.create_batch_file(experiment)
+                batch_path = os.path.join(platform.get_directory(experiment), "batch.sh")
+                self.assertTrue(os.path.exists(batch_path))
+                with open(batch_path, 'r') as batch_file:
+                    contents = batch_file.read()
+            finally:
+                IdmConfigParser.clear_instance()
+                if original_config is None:
+                    os.environ.pop("IDMTOOLS_CONFIG_FILE", None)
+                else:
+                    os.environ["IDMTOOLS_CONFIG_FILE"] = original_config
+        return contents
+
     # Test platform slurm_fields property
     def test_slurm_platform_fields(self):
         actual_field_set = self.platform.slurm_fields
@@ -195,43 +235,23 @@ class TestSlurmOperations(ITestWithPersistence):
         shutil.rmtree(exp_dir)
         self.assertFalse(os.path.exists(job_path))
 
-    def test_simtools_ini_flag_updates_batch_script(self):
-        original_config = os.environ.get("IDMTOOLS_CONFIG_FILE")
-        IdmConfigParser.clear_instance()
-        with tempfile.TemporaryDirectory() as temp_dir:
-            job_dir = os.path.join(temp_dir, "jobs")
-            os.makedirs(job_dir, exist_ok=True)
-            simtools_ini = os.path.join(temp_dir, "simtools.ini")
-            config_lines = [
-                "[SLURM_SIMTOOLS]",
-                "type = Slurm",
-                f"job_directory = {job_dir}",
-                "propogate_slurm_env_var = False"
-            ]
-            with open(simtools_ini, "w") as config_file:
-                config_file.write("\n".join(config_lines))
-            os.environ["IDMTOOLS_CONFIG_FILE"] = simtools_ini
-            IdmConfigParser.clear_instance()
-            try:
-                platform = Platform('SLURM_SIMTOOLS')
-                slurm_op = SlurmOperations(platform=platform)
-                suite = Suite(name="Suite")
-                experiment = Experiment(name="ExpSimtools")
-                experiment.parent = suite
-                slurm_op.mk_directory(experiment)
-                slurm_op.create_batch_file(experiment)
-                batch_path = os.path.join(platform.get_directory(experiment), "batch.sh")
-                self.assertTrue(os.path.exists(batch_path))
-                with open(batch_path, 'r') as batch_file:
-                    contents = batch_file.read()
-                self.assertIn("unset SLURM_JOB_ID", contents)
-                self.assertIn("unset SLURM_MEM_PER_NODE", contents)
-            finally:
-                IdmConfigParser.clear_instance()
-                if original_config is None:
-                    os.environ.pop("IDMTOOLS_CONFIG_FILE", None)
-                else:
-                    os.environ["IDMTOOLS_CONFIG_FILE"] = original_config
+    def test_simtools_ini_propogate_slurm_env_var_updates_batch_script(self):
+        contents = self._generate_batch_from_simtools_config([
+            "propogate_slurm_env_var = False"
+        ])
+        self.assertIn("unset SLURM_JOB_ID", contents)
+        self.assertIn("unset SLURM_MEM_PER_NODE", contents)
+
+    def test_simtools_ini_propogate_true_or_default_keeps_slurm_env_vars(self):
+        scenarios = {
+            "explicit_true": ["propogate_slurm_env_var = True"],
+            "unspecified": None,
+        }
+        for name, extra_lines in scenarios.items():
+            with self.subTest(case=name):
+                contents = self._generate_batch_from_simtools_config(extra_lines)
+                self.assertNotIn("unset SLURM_JOB_ID", contents)
+                self.assertNotIn("unset SLURM_MEM_PER_NODE", contents)
 
     # Test SlurmOperations create_batch_file for simulation
     def test_SlurmOperations_create_batch_file_simulation(self):

--- a/idmtools_platform_slurm/tests/test_slurm_operations.py
+++ b/idmtools_platform_slurm/tests/test_slurm_operations.py
@@ -235,16 +235,16 @@ class TestSlurmOperations(ITestWithPersistence):
         shutil.rmtree(exp_dir)
         self.assertFalse(os.path.exists(job_path))
 
-    def test_simtools_ini_propogate_slurm_env_var_updates_batch_script(self):
+    def test_simtools_ini_propagate_slurm_env_var_updates_batch_script(self):
         contents = self._generate_batch_from_simtools_config([
-            "propogate_slurm_env_var = False"
+            "propagate_slurm_env_var = False"
         ])
         self.assertIn("unset SLURM_JOB_ID", contents)
         self.assertIn("unset SLURM_MEM_PER_NODE", contents)
 
-    def test_simtools_ini_propogate_true_or_default_keeps_slurm_env_vars(self):
+    def test_simtools_ini_propagate_true_or_default_keeps_slurm_env_vars(self):
         scenarios = {
-            "explicit_true": ["propogate_slurm_env_var = True"],
+            "explicit_true": ["propagate_slurm_env_var = True"],
             "unspecified": None,
         }
         for name, extra_lines in scenarios.items():
@@ -252,6 +252,12 @@ class TestSlurmOperations(ITestWithPersistence):
                 contents = self._generate_batch_from_simtools_config(extra_lines)
                 self.assertNotIn("unset SLURM_JOB_ID", contents)
                 self.assertNotIn("unset SLURM_MEM_PER_NODE", contents)
+
+    def test_legacy_propogate_key_still_supported(self):
+        contents = self._generate_batch_from_simtools_config([
+            "propogate_slurm_env_var = False"
+        ])
+        self.assertIn("unset SLURM_JOB_ID", contents)
 
     # Test SlurmOperations create_batch_file for simulation
     def test_SlurmOperations_create_batch_file_simulation(self):


### PR DESCRIPTION
Our (NYU) HPC policy does not allow you to run python on the head node. Therefore, we commonly will pull down a node into an interactive terminal using srun. The default behavior in slurm is to inherit environment variables from parent environments. This becomes a problem when we create a job via emodpy. There are variables that should not be inherited, and we get a weird cpu bind error (see bottom, A).

I added an option in slurm_platform.py and the batch.sh.jinja2 file to unset the parent env variables. The default behavior is unchanged.

Additionally, I was unable to build idmtools_platform_slurm due to a dependency issue.  There was a dependency for "idmtools_platform_general~=3.0.0", which I was unable to build due to a idmtools_cli~=3.00 dependency.  I went out on a limb and saw the comps platform required idmtools~=3.0.0, and updated the dependencies in slurm to reflect that. I am not super confident in my change, but it worked. I would love some insight into whether or not my change was kosher.

Error message from slurm issue:
srun: error: CPU binding outside of job step allocation, allocated CPUs are: 0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000.
srun: error: Task launch for StepId=18072825.0 failed on node cl40s-8001: Unable to satisfy cpu bind request
srun: error: Application launch failed: Unable to satisfy cpu bind request
srun: Job step aborted
