### PR TITLE
Pypi docs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,9 +19,9 @@ Model implementations
 **Modules:**
 
 - `python` - Python model support
-  - `PythonTask`
-  - `JSONConfiguredPythonTask`
-  - `SingularityJSONConfiguredPythonTask`
+    - `PythonTask`
+    - `JSONConfiguredPythonTask`
+    - `SingularityJSONConfiguredPythonTask`
 - `r` - R model support
 - `templated_script_task` - Templated models
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,6 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
-    - navigation.sections
-    - navigation.expand
     - navigation.path
     - navigation.top
     - navigation.indexes


### PR DESCRIPTION
Addressed the following issues:
1. "Data Analysis" behave not consistent with 'Tutorial' and 'API'
In the left sidebar, under the API tab, the "Data Analysis" section was automatically expanded — showing its sub-items (Analyzers, Analyze Manager, Platform Analysis) immediately without any user interaction.

Under the Tutorial tab, "Data Analysis" is a flat leaf link and shows no sub-items unless navigated to — which was the desired behavior.

2. Indentation issue with `python` - Python model support